### PR TITLE
Updates: Abstractions, AspNetCore, EntityFrameworkCore, MediatR, Obse…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Geneirodan.Packages
+
+Libraries and a sample API for CQRS with MediatR, EF Core, ASP.NET Core, and OpenTelemetry.
+
+## Packages
+
+- **Geneirodan.Abstractions** — domain interfaces (`IEntity`, `IUser`), repositories (`IRepository`, `IUnitOfWork`), and mapping.
+- **Geneirodan.EntityFrameworkCore** — implementations of `IRepository` and `IUnitOfWork` for EF Core.
+- **Geneirodan.MediatR** — pipeline behaviors: logging, authorization, validation, and unhandled exception handling.
+- **Geneirodan.AspNetCore** — JWT/auth, `IUser` from HTTP context, localization, health checks, and problem-details exception handler.
+- **Geneirodan.Observability** — Serilog and OpenTelemetry wiring.
+
+## Sample API and MediatR pipeline
+
+The **Sample** project (`Sample/Geneirodan.SampleApi`) demonstrates the MediatR pipeline and how to send commands and queries.
+
+### Pipeline order
+
+When you call `ISender.Send(command)` or `ISender.Send(query)`, the pipeline runs in this order:
+
+1. **Logging** — logs the request name and optional user ID.
+2. **Authorization** — if the request type has `[Authorize]`, checks that the current user is authenticated and (when `Roles` is set) in one of the allowed roles.
+3. **Validation** — runs FluentValidation validators for the request; returns an invalid result without calling the handler if validation fails.
+4. **Unhandled exception** — catches exceptions from the handler and rethrows so the ASP.NET Core exception handler can return problem details.
+5. **Handler** — the command/query handler runs last.
+
+### Sample commands
+
+- **Command** — no auth; either succeeds or throws when `ShouldFail` is true (used to demonstrate exception handling).
+- **ValidatedCommand** — has a FluentValidation validator for `Email`; handler runs only if validation passes.
+- **AuthorizedCommand** — requires an authenticated user (`[Authorize]`).
+- **AdminCommand** — requires the user to be in the Admin role (`[Authorize(Roles = "Admin")]`).
+
+### Wiring in the Sample
+
+In `Program.cs`, the pipeline and validators are registered with the current assembly:
+
+```csharp
+builder.Services.AddMediatRPipeline(Assembly.GetExecutingAssembly());
+builder.Services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
+```
+
+To add endpoints that send commands or queries and map `Result`/`Result<T>` to HTTP responses, use `ResultConverter.MapResult` (e.g. in minimal APIs or controllers).
+
+### Running and testing
+
+- Run the Sample API from `Sample/Geneirodan.SampleApi`.
+- Integration tests for the pipeline and for EF Core repository/unit-of-work live in `Tests/`.

--- a/Sample/Geneirodan.SampleApi/Application/Commands/AdminCommand.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/AdminCommand.cs
@@ -8,15 +8,13 @@ namespace Geneirodan.SampleApi.Application.Commands;
 /// <summary>
 /// Sample command protected by <see cref="AuthorizeAttribute"/> with <c>Roles = "Admin"</c>: only users in the Admin role can execute it.
 /// Demonstrates role-based authorization in the MediatR pipeline; returns Forbidden if the user is not in the Admin role.
-/// When authorized, returns success or <see cref="Result.Error"/> when <see cref="ShouldFail"/> is <see langword="true"/>.
+/// When authorized, returns success or error result depending on <see cref="ShouldFail"/> value.
 /// </summary>
-/// <param name="ShouldFail">When <see langword="true"/>, returns <see cref="Result.Error"/> instead of success.</param>
+/// <param name="ShouldFail">When <see langword="true"/>, returns error instead of success.</param>
 [Authorize(Roles = "Admin")]
 public sealed record AdminCommand(bool ShouldFail) : ICommand
 {
-    /// <summary>
-    /// Handles the command after role authorization has passed.
-    /// </summary>
+    /// <inheritdoc/>
     public sealed class Handler : IRequestHandler<AdminCommand, Result>
     {
         /// <inheritdoc/>

--- a/Sample/Geneirodan.SampleApi/Application/Commands/AdminCommand.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/AdminCommand.cs
@@ -5,12 +5,22 @@ using MediatR;
 
 namespace Geneirodan.SampleApi.Application.Commands;
 
+/// <summary>
+/// Sample command protected by <see cref="AuthorizeAttribute"/> with <c>Roles = "Admin"</c>: only users in the Admin role can execute it.
+/// Demonstrates role-based authorization in the MediatR pipeline; returns Forbidden if the user is not in the Admin role.
+/// When authorized, returns success or <see cref="Result.Error"/> when <see cref="ShouldFail"/> is <see langword="true"/>.
+/// </summary>
+/// <param name="ShouldFail">When <see langword="true"/>, returns <see cref="Result.Error"/> instead of success.</param>
 [Authorize(Roles = "Admin")]
 public sealed record AdminCommand(bool ShouldFail) : ICommand
 {
+    /// <summary>
+    /// Handles the command after role authorization has passed.
+    /// </summary>
     public sealed class Handler : IRequestHandler<AdminCommand, Result>
     {
-        public Task<Result> Handle(AdminCommand request, CancellationToken cancellationToken) => 
+        /// <inheritdoc/>
+        public Task<Result> Handle(AdminCommand request, CancellationToken cancellationToken) =>
             Task.FromResult(request.ShouldFail ? Result.Error("SomeSortOfError") : Result.Success());
     }
 }

--- a/Sample/Geneirodan.SampleApi/Application/Commands/AuthorizedCommand.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/AuthorizedCommand.cs
@@ -1,16 +1,26 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
 using Geneirodan.MediatR.Abstractions;
 using Geneirodan.MediatR.Attributes;
 using MediatR;
 
 namespace Geneirodan.SampleApi.Application.Commands;
 
+/// <summary>
+/// Sample command protected by <see cref="AuthorizeAttribute"/> (no roles): requires an authenticated user.
+/// Demonstrates <see cref="Geneirodan.MediatR.Behaviors.AuthorizationBehavior{TRequest, TResponse}"/>; returns Unauthorized if <see cref="IUser.Id"/> is empty.
+/// When authorized, returns success or <see cref="Result.Error"/> when <see cref="ShouldFail"/> is <see langword="true"/>.
+/// </summary>
+/// <param name="ShouldFail">When <see langword="true"/>, returns <see cref="Result.Error"/> instead of success.</param>
 [Authorize]
 public sealed record AuthorizedCommand(bool ShouldFail) : ICommand
 {
+    /// <summary>
+    /// Handles the command after authorization has passed.
+    /// </summary>
     public sealed class Handler : IRequestHandler<AuthorizedCommand, Result>
     {
-        public Task<Result> Handle(AuthorizedCommand request, CancellationToken cancellationToken) => 
+        /// <inheritdoc/>
+        public Task<Result> Handle(AuthorizedCommand request, CancellationToken cancellationToken) =>
             Task.FromResult(request.ShouldFail ? Result.Error("SomeSortOfError") : Result.Success());
     }
 }

--- a/Sample/Geneirodan.SampleApi/Application/Commands/AuthorizedCommand.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/AuthorizedCommand.cs
@@ -1,22 +1,21 @@
 using Ardalis.Result;
 using Geneirodan.MediatR.Abstractions;
 using Geneirodan.MediatR.Attributes;
+using Geneirodan.MediatR.Behaviors;
 using MediatR;
 
 namespace Geneirodan.SampleApi.Application.Commands;
 
 /// <summary>
 /// Sample command protected by <see cref="AuthorizeAttribute"/> (no roles): requires an authenticated user.
-/// Demonstrates <see cref="Geneirodan.MediatR.Behaviors.AuthorizationBehavior{TRequest, TResponse}"/>; returns Unauthorized if <see cref="IUser.Id"/> is empty.
-/// When authorized, returns success or <see cref="Result.Error"/> when <see cref="ShouldFail"/> is <see langword="true"/>.
+/// Demonstrates <see cref="AuthorizationBehavior{TRequest, TResponse}"/>; returns Unauthorized if <see cref="IUser.Id"/> is empty.
+/// When authorized, returns success or error result depending on <see cref="ShouldFail"/> value.
 /// </summary>
-/// <param name="ShouldFail">When <see langword="true"/>, returns <see cref="Result.Error"/> instead of success.</param>
+/// <param name="ShouldFail">When <see langword="true"/>, returns error instead of success.</param>
 [Authorize]
 public sealed record AuthorizedCommand(bool ShouldFail) : ICommand
 {
-    /// <summary>
-    /// Handles the command after authorization has passed.
-    /// </summary>
+    /// <inheritdoc/>
     public sealed class Handler : IRequestHandler<AuthorizedCommand, Result>
     {
         /// <inheritdoc/>

--- a/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
@@ -8,8 +8,7 @@ using MediatR;
 namespace Geneirodan.SampleApi.Application.Commands;
 
 /// <summary>
-/// Sample command that either succeeds or throws an exception when <see cref="ShouldFail"/> is <see langword="true"/>.
-/// Used to demonstrate the MediatR pipeline and exception handling (e.g. <see cref="UnhandledExceptionBehavior{TRequest, TResponse}"/> and ASP.NET Core exception handler).
+/// Sample command used by tests and documentation to exercise the MediatR pipeline and exception handling.
 /// </summary>
 /// <param name="ShouldFail">When <see langword="true"/>, the handler throws; otherwise returns success.</param>
 public sealed record Command(bool ShouldFail) : ICommand
@@ -24,8 +23,7 @@ public sealed record Command(bool ShouldFail) : ICommand
 }
 
 /// <summary>
-/// Sample command that carries an email and is validated by FluentValidation before the handler runs.
-/// Demonstrates <see cref="ValidationBehavior{TRequest, TResponse}"/> and <see cref="AbstractValidator{T}"/>.
+/// Sample command that demonstrates FluentValidation before the handler runs.
 /// </summary>
 /// <param name="Email">The email to validate; must be non-empty and a valid email address format.</param>
 public sealed record ValidatedCommand(string Email) : ICommand

--- a/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
@@ -1,4 +1,4 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
 using FluentValidation;
 using Geneirodan.MediatR.Abstractions;
 using JetBrains.Annotations;
@@ -6,26 +6,50 @@ using MediatR;
 
 namespace Geneirodan.SampleApi.Application.Commands;
 
+/// <summary>
+/// Sample command that either succeeds or throws an exception when <see cref="ShouldFail"/> is <see langword="true"/>.
+/// Used to demonstrate the MediatR pipeline and exception handling (e.g. <see cref="Geneirodan.MediatR.Behaviors.UnhandledExceptionBehavior{TRequest, TResponse}"/> and ASP.NET Core exception handler).
+/// </summary>
+/// <param name="ShouldFail">When <see langword="true"/>, the handler throws; otherwise returns <see cref="Result.Success"/>.</param>
 public sealed record Command(bool ShouldFail) : ICommand
 {
+    /// <summary>
+    /// Handles the command: returns success or throws so that the pipeline can log and the API can return problem details.
+    /// </summary>
     public sealed class Handler : IRequestHandler<Command, Result>
     {
+        /// <inheritdoc/>
         public Task<Result> Handle(Command request, CancellationToken cancellationToken) =>
             Task.FromResult(request.ShouldFail ? throw new Exception("SomeSortOfError") : Result.Success());
     }
 }
 
+/// <summary>
+/// Sample command that carries an email and is validated by FluentValidation before the handler runs.
+/// Demonstrates <see cref="Geneirodan.MediatR.Behaviors.ValidationBehavior{TRequest, TResponse}"/> and <see cref="AbstractValidator{T}"/>.
+/// </summary>
+/// <param name="Email">The email to validate; must be non-empty and a valid email address format.</param>
 public sealed record ValidatedCommand(string Email) : ICommand
 {
+    /// <summary>
+    /// Handles the command after validation has passed; returns success.
+    /// </summary>
     public sealed class Handler : IRequestHandler<ValidatedCommand, Result>
     {
+        /// <inheritdoc/>
         public Task<Result> Handle(ValidatedCommand request, CancellationToken cancellationToken) =>
             Task.FromResult(Result.Success());
     }
 
+    /// <summary>
+    /// FluentValidation validator for <see cref="ValidatedCommand"/>. Runs in the pipeline before the handler.
+    /// </summary>
     [UsedImplicitly]
     public sealed class Validator : AbstractValidator<ValidatedCommand>
     {
+        /// <summary>
+        /// Configures rules: <see cref="ValidatedCommand.Email"/> must be non-empty and a valid email address.
+        /// </summary>
         public Validator()
         {
             RuleFor(x => x.Email).NotEmpty().EmailAddress();

--- a/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
@@ -1,6 +1,7 @@
 using Ardalis.Result;
 using FluentValidation;
 using Geneirodan.MediatR.Abstractions;
+using Geneirodan.MediatR.Behaviors;
 using JetBrains.Annotations;
 using MediatR;
 
@@ -8,14 +9,12 @@ namespace Geneirodan.SampleApi.Application.Commands;
 
 /// <summary>
 /// Sample command that either succeeds or throws an exception when <see cref="ShouldFail"/> is <see langword="true"/>.
-/// Used to demonstrate the MediatR pipeline and exception handling (e.g. <see cref="Geneirodan.MediatR.Behaviors.UnhandledExceptionBehavior{TRequest, TResponse}"/> and ASP.NET Core exception handler).
+/// Used to demonstrate the MediatR pipeline and exception handling (e.g. <see cref="UnhandledExceptionBehavior{TRequest, TResponse}"/> and ASP.NET Core exception handler).
 /// </summary>
-/// <param name="ShouldFail">When <see langword="true"/>, the handler throws; otherwise returns <see cref="Result.Success"/>.</param>
+/// <param name="ShouldFail">When <see langword="true"/>, the handler throws; otherwise returns success.</param>
 public sealed record Command(bool ShouldFail) : ICommand
 {
-    /// <summary>
-    /// Handles the command: returns success or throws so that the pipeline can log and the API can return problem details.
-    /// </summary>
+    /// <inheritdoc/>
     public sealed class Handler : IRequestHandler<Command, Result>
     {
         /// <inheritdoc/>
@@ -26,14 +25,12 @@ public sealed record Command(bool ShouldFail) : ICommand
 
 /// <summary>
 /// Sample command that carries an email and is validated by FluentValidation before the handler runs.
-/// Demonstrates <see cref="Geneirodan.MediatR.Behaviors.ValidationBehavior{TRequest, TResponse}"/> and <see cref="AbstractValidator{T}"/>.
+/// Demonstrates <see cref="ValidationBehavior{TRequest, TResponse}"/> and <see cref="AbstractValidator{T}"/>.
 /// </summary>
 /// <param name="Email">The email to validate; must be non-empty and a valid email address format.</param>
 public sealed record ValidatedCommand(string Email) : ICommand
 {
-    /// <summary>
-    /// Handles the command after validation has passed; returns success.
-    /// </summary>
+    /// <inheritdoc/>
     public sealed class Handler : IRequestHandler<ValidatedCommand, Result>
     {
         /// <inheritdoc/>
@@ -41,15 +38,10 @@ public sealed record ValidatedCommand(string Email) : ICommand
             Task.FromResult(Result.Success());
     }
 
-    /// <summary>
-    /// FluentValidation validator for <see cref="ValidatedCommand"/>. Runs in the pipeline before the handler.
-    /// </summary>
+    /// <inheritdoc/>
     [UsedImplicitly]
     public sealed class Validator : AbstractValidator<ValidatedCommand>
     {
-        /// <summary>
-        /// Configures rules: <see cref="ValidatedCommand.Email"/> must be non-empty and a valid email address.
-        /// </summary>
         public Validator()
         {
             RuleFor(x => x.Email).NotEmpty().EmailAddress();

--- a/Sample/Geneirodan.SampleApi/Domain/DomainEntity.cs
+++ b/Sample/Geneirodan.SampleApi/Domain/DomainEntity.cs
@@ -2,8 +2,20 @@ using Geneirodan.Abstractions.Domain;
 
 namespace Geneirodan.SampleApi.Domain;
 
+/// <summary>
+/// Sample domain entity used by the example API and persistence layer.
+/// Implements <see cref="IEntity{TKey}"/> with integer key so it can be stored via the repository abstraction
+/// and mapped in <see cref="Persistence.ApplicationContext"/>.
+/// </summary>
 public class DomainEntity : IEntity<int>
 {
+    /// <summary>
+    /// Unique identifier of the entity. Set by the database or seed data.
+    /// </summary>
     public int Id { get; init; }
+
+    /// <summary>
+    /// Display name of the entity. Required and limited in length by the persistence configuration.
+    /// </summary>
     public required string Name { get; set; }
 }

--- a/Sample/Geneirodan.SampleApi/IApiMarker.cs
+++ b/Sample/Geneirodan.SampleApi/IApiMarker.cs
@@ -1,3 +1,7 @@
 namespace Geneirodan.SampleApi;
 
+/// <summary>
+/// Marker interface for the sample API assembly. Used by tests or other projects that need to reference the API assembly
+/// (e.g. for assembly scanning or to obtain <see cref="System.Reflection.Assembly"/> for MediatR or FluentValidation).
+/// </summary>
 public interface IApiMarker;

--- a/Sample/Geneirodan.SampleApi/Persistence/ApplicationContext.cs
+++ b/Sample/Geneirodan.SampleApi/Persistence/ApplicationContext.cs
@@ -1,3 +1,4 @@
+using Geneirodan.EntityFrameworkCore;
 using Geneirodan.SampleApi.Domain;
 using Microsoft.EntityFrameworkCore;
 
@@ -6,7 +7,7 @@ namespace Geneirodan.SampleApi.Persistence;
 /// <summary>
 /// Entity Framework Core DbContext for the sample API. Exposes <see cref="DomainEntity"/> as <see cref="DbSet"/>.
 /// On construction, calls <see cref="DbContext.Database.EnsureCreated"/> so the database and schema are created if missing.
-/// Used with <see cref="Geneirodan.EntityFrameworkCore.Repository{TEntity, TKey}"/> and <see cref="Geneirodan.EntityFrameworkCore.UnitOfWork"/> for the sample.
+/// Used with <see cref="Repository{TEntity, TKey}"/> and <see cref="UnitOfWork"/> for the sample.
 /// </summary>
 public sealed class ApplicationContext : DbContext
 {

--- a/Sample/Geneirodan.SampleApi/Persistence/ApplicationContext.cs
+++ b/Sample/Geneirodan.SampleApi/Persistence/ApplicationContext.cs
@@ -1,14 +1,29 @@
-﻿using Geneirodan.SampleApi.Domain;
+using Geneirodan.SampleApi.Domain;
 using Microsoft.EntityFrameworkCore;
 
 namespace Geneirodan.SampleApi.Persistence;
 
+/// <summary>
+/// Entity Framework Core DbContext for the sample API. Exposes <see cref="DomainEntity"/> as <see cref="DbSet"/>.
+/// On construction, calls <see cref="DbContext.Database.EnsureCreated"/> so the database and schema are created if missing.
+/// Used with <see cref="Geneirodan.EntityFrameworkCore.Repository{TEntity, TKey}"/> and <see cref="Geneirodan.EntityFrameworkCore.UnitOfWork"/> for the sample.
+/// </summary>
 public sealed class ApplicationContext : DbContext
 {
+    /// <summary>
+    /// Initializes the context with the given options and ensures the database is created.
+    /// </summary>
+    /// <param name="options">The options (e.g. from dependency injection) specifying the database provider and connection.</param>
     public ApplicationContext(DbContextOptions<ApplicationContext> options) : base(options) => Database.EnsureCreated();
 
+    /// <summary>
+    /// The set of <see cref="DomainEntity"/> entities. Used by the repository and for direct querying in tests or handlers.
+    /// </summary>
     public DbSet<DomainEntity> DbSet { get; set; }
 
+    /// <summary>
+    /// Configures the <see cref="DomainEntity"/> model: primary key, seed data, and <see cref="DomainEntity.Name"/> max length.
+    /// </summary>
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<DomainEntity>().HasData(

--- a/Sample/Geneirodan.SampleApi/Program.cs
+++ b/Sample/Geneirodan.SampleApi/Program.cs
@@ -1,3 +1,8 @@
+/// <summary>
+/// Sample API entry point: registers MediatR pipeline (with current assembly), FluentValidation validators, Serilog, and OpenTelemetry.
+/// Maps a minimal root endpoint; add more endpoints that send commands/queries and use <see cref="ResultConverter.MapResult"/> for responses.
+/// </summary>
+
 using System.Reflection;
 using FluentValidation;
 using Geneirodan.MediatR;

--- a/Src/Geneirodan.Abstractions/Domain/Entity.cs
+++ b/Src/Geneirodan.Abstractions/Domain/Entity.cs
@@ -1,18 +1,23 @@
+using Geneirodan.Abstractions.Repositories;
 using JetBrains.Annotations;
 
 namespace Geneirodan.Abstractions.Domain;
 
 /// <summary>
-/// Represents an abstract base class for entities that implement <see cref="IEntity{TKey}"/>.
-/// This class provides a common implementation for entities that have a unique identifier of type <typeparamref name="TKey"/>.
+/// Represents an abstract base class for domain entities that implement <see cref="IEntity{TKey}"/>.
+/// Inherit from this class when defining domain entities so that they share a common identifier contract
+/// and can be used with <see cref="IRepository{TEntity,TKey}"/> and Entity Framework Core mappings.
 /// </summary>
 /// <typeparam name="TKey">
-/// <inheritdoc/>
+/// The type of the identifier. It must implement <see cref="IEquatable{TKey}"/> for repository and EF Core support.
 /// </typeparam>
 [PublicAPI]
-public abstract class Entity<TKey> : IEntity<TKey> 
+public abstract class Entity<TKey> : IEntity<TKey>
     where TKey : IEquatable<TKey>
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// Unique identifier of the entity.
+    /// Required and init-only; typically set by the persistence layer (e.g. database or in-memory store) on insert.
+    /// </summary>
     public required TKey Id { get; init; }
 }

--- a/Src/Geneirodan.Abstractions/Domain/IEntity.cs
+++ b/Src/Geneirodan.Abstractions/Domain/IEntity.cs
@@ -1,18 +1,26 @@
+using Geneirodan.Abstractions.Repositories;
+
 namespace Geneirodan.Abstractions.Domain;
 
 /// <summary>
 /// Defines a contract for an entity that has an identifier of type <typeparamref name="TKey"/>.
-/// This interface is typically used to represent domain entities with a unique identifier.
+/// This interface is used by the domain layer and by <see cref="IRepository{TEntity,TKey}"/> to represent
+/// persistable entities with a unique key. All entities exposed through repositories must implement this interface.
 /// </summary>
 /// <typeparam name="TKey">
-/// The type of the identifier for the entity. It must implement <see cref="IEquatable{TKey}"/> to support 
-/// equality comparisons for determining if two entity identifiers are equal.
+/// The type of the identifier for the entity. It must implement <see cref="IEquatable{TKey}"/> to support
+/// equality comparisons in repository lookups and to satisfy Entity Framework Core key constraints.
 /// </typeparam>
-public interface IEntity<out TKey> 
+/// <remarks>
+/// <seealso cref="Entity{TKey}"/> — base class for domain entities implementing this interface.<br/>
+/// <seealso cref="IRepository{TEntity,TKey}"/> — contract that consumes <see cref="IEntity{TKey}"/>.
+/// </remarks>
+public interface IEntity<out TKey>
     where TKey : IEquatable<TKey>
 {
     /// <summary>
     /// Unique identifier of the entity.
+    /// Used by the repository layer for lookups, updates, and deletes; must be set before persistence.
     /// </summary>
     public TKey Id { get; }
 }

--- a/Src/Geneirodan.Abstractions/Domain/IUser.cs
+++ b/Src/Geneirodan.Abstractions/Domain/IUser.cs
@@ -1,20 +1,24 @@
 namespace Geneirodan.Abstractions.Domain;
 
 /// <summary>
-/// Represents a user in the system with basic properties and capabilities, such as the user's identifier and role-based access.
+/// Represents the current user in the system with identifier and role-based access.
+/// Implemented in the API layer (e.g. <c>HttpUser</c> in Geneirodan.AspNetCore) using the current HTTP context (claims); used by
+/// MediatR authorization and handlers to obtain the acting user without depending on ASP.NET Core types.
 /// </summary>
 public interface IUser
 {
     /// <summary>
     /// Unique identifier of the user.
-    /// The identifier is nullable in case the user is not yet assigned an ID (e.g., for anonymous users).
+    /// Sourced from the authentication provider (e.g. JWT <c>NameIdentifier</c> claim). Returns <see cref="Guid.Empty"/>
+    /// when the user is not authenticated (e.g. anonymous requests).
     /// </summary>
     Guid Id { get; }
 
     /// <summary>
-    /// Determines whether the user is in the specified role.
+    /// Determines whether the current user is in the specified role.
+    /// Used by authorization policies and <c>[Authorize]</c> / <c>[Authorize(Roles = "...")]</c> to enforce role-based access.
     /// </summary>
-    /// <param name="role">The name of the role to check against the user's roles.</param>
-    /// <returns>True if the user is in the specified role; otherwise, false.</returns>
+    /// <param name="role">The name of the role to check against the user's roles (e.g. "Admin", "User").</param>
+    /// <returns><see langword="true"/> if the user is in the specified role; otherwise, <see langword="false"/>.</returns>
     bool IsInRole(string role);
 }

--- a/Src/Geneirodan.Abstractions/Mapping/IMapper.cs
+++ b/Src/Geneirodan.Abstractions/Mapping/IMapper.cs
@@ -1,25 +1,18 @@
 namespace Geneirodan.Abstractions.Mapping;
 
 /// <summary>
-/// Defines a contract for mapping an object of type <typeparamref name="TSource"/>
-/// to an object of type <typeparamref name="TDestination"/>.
+/// Defines a contract for mapping an object of type <typeparamref name="TSource"/> to <typeparamref name="TDestination"/>.
+/// Used to separate domain entities from DTOs or API models; implementations can be hand-written or backed by a mapping library.
+/// The EntityFrameworkCore package provides <c>ProjectTo</c> extension methods that use this interface for queryable-to-queryable mapping.
 /// </summary>
-/// <typeparam name="TSource">
-/// The type of the source object to be mapped.
-/// </typeparam>
-/// <typeparam name="TDestination">
-/// The type of the destination object after mapping.
-/// </typeparam>
+/// <typeparam name="TSource">The type of the source object to be mapped (e.g. entity or domain model).</typeparam>
+/// <typeparam name="TDestination">The type of the destination object after mapping (e.g. DTO or response model).</typeparam>
 public interface IMapper<in TSource, out TDestination>
 {
     /// <summary>
-    /// Maps the source object to a destination object.
+    /// Maps the source object to a destination object. Implementations must not return <see langword="null"/> unless <typeparamref name="TDestination"/> is nullable.
     /// </summary>
-    /// <param name="source">
-    /// The source object to be mapped.
-    /// </param>
-    /// <returns>
-    /// The mapped destination object.
-    /// </returns>
+    /// <param name="source">The source object to be mapped.</param>
+    /// <returns>The mapped destination object.</returns>
     TDestination Map(TSource source);
 }

--- a/Src/Geneirodan.Abstractions/Repositories/IRepository.cs
+++ b/Src/Geneirodan.Abstractions/Repositories/IRepository.cs
@@ -12,87 +12,26 @@ namespace Geneirodan.Abstractions.Repositories;
 /// <seealso cref="IUnitOfWork"/> — use together for transactional persistence.<br/>
 /// <seealso cref="IEntity{TKey}"/> — <typeparamref name="TEntity"/> must implement this interface.
 /// </remarks>
-/// <typeparam name="TEntity">
-/// The type of the entity that the repository manages. It must implement the <see cref="IEntity{TKey}"/> interface.
-/// </typeparam>
-/// <typeparam name="TKey">
-/// The type of the primary key of the entity. It must implement <see cref="IEquatable{TKey}"/> for lookups.
-/// </typeparam>
+/// <typeparam name="TEntity">The type of the entity that the repository manages.</typeparam>
+/// <typeparam name="TKey">The type of the primary key of the entity; must implement <see cref="IEquatable{TKey}"/>.</typeparam>
 public interface IRepository<TEntity, in TKey>
     where TEntity : IEntity<TKey>
     where TKey : IEquatable<TKey>
 {
     /// <summary>
-    /// Asynchronously retrieves an entity by its identifier.
+    /// Looks up an entity by identifier and returns <see langword="null"/> if it does not exist instead of throwing.
     /// </summary>
-    /// <param name="id">
-    /// The identifier of the entity to retrieve.
-    /// </param>
-    /// <param name="token">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is the entity with the specified identifier, or <see langword="null"/> if no entity is found.
-    /// </returns>
     Task<TEntity?> FindAsync(TKey id, CancellationToken token = default);
 
-    /// <summary>
-    /// Asynchronously determines whether an entity with the specified identifier exists.
-    /// </summary>
-    /// <param name="id">
-    /// The identifier of the entity to check for existence.
-    /// </param>
-    /// <param name="token">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is <see langword="true"/> if an entity with the specified identifier exists; otherwise, <see langword="false"/>.
-    /// </returns>
+    /// <summary>Asynchronously determines whether an entity with the specified identifier exists.</summary>
     Task<bool> ExistsAsync(TKey id, CancellationToken token = default);
 
-    /// <summary>
-    /// Asynchronously adds a new entity to the repository.
-    /// </summary>
-    /// <param name="entity">
-    /// The entity to add.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is the added entity.
-    /// </returns>
+    /// <summary>Asynchronously adds the entity to the repository.</summary>
     Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Asynchronously updates an existing entity in the repository.
-    /// </summary>
-    /// <param name="entity">
-    /// The entity to update.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is the updated entity.
-    /// </returns>
+    /// <summary>Asynchronously updates the entity in the repository.</summary>
     Task<TEntity> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Asynchronously deletes an entity from the repository.
-    /// </summary>
-    /// <param name="entity">
-    /// The entity to delete.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.
-    /// </returns>
+    /// <summary>Asynchronously deletes the entity from the repository.</summary>
     Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default);
 }

--- a/Src/Geneirodan.Abstractions/Repositories/IRepository.cs
+++ b/Src/Geneirodan.Abstractions/Repositories/IRepository.cs
@@ -5,12 +5,18 @@ namespace Geneirodan.Abstractions.Repositories;
 /// <summary>
 /// Defines the contract for a repository that manages entities of type <typeparamref name="TEntity"/>
 /// with a primary key of type <typeparamref name="TKey"/>.
+/// Repositories abstract persistence and are used together with <see cref="IUnitOfWork"/> for transactional
+/// operations. The concrete implementation is provided by the Geneirodan.EntityFrameworkCore package.
 /// </summary>
+/// <remarks>
+/// <seealso cref="IUnitOfWork"/> — use together for transactional persistence.<br/>
+/// <seealso cref="IEntity{TKey}"/> — <typeparamref name="TEntity"/> must implement this interface.
+/// </remarks>
 /// <typeparam name="TEntity">
 /// The type of the entity that the repository manages. It must implement the <see cref="IEntity{TKey}"/> interface.
 /// </typeparam>
 /// <typeparam name="TKey">
-/// The type of the primary key of the entity. It must implement <see cref="IEquatable{TKey}"/>.
+/// The type of the primary key of the entity. It must implement <see cref="IEquatable{TKey}"/> for lookups.
 /// </typeparam>
 public interface IRepository<TEntity, in TKey>
     where TEntity : IEntity<TKey>

--- a/Src/Geneirodan.Abstractions/Repositories/ITransaction.cs
+++ b/Src/Geneirodan.Abstractions/Repositories/ITransaction.cs
@@ -3,17 +3,18 @@ using JetBrains.Annotations;
 namespace Geneirodan.Abstractions.Repositories;
 
 /// <summary>
-/// Defines an interface for managing transactions with asynchronous commit and rollback operations.
+/// Represents a database transaction started via <see cref="IUnitOfWork.BeginTransactionAsync"/>.
+/// Call <see cref="CommitAsync"/> to commit; if the instance is disposed without committing, the transaction is rolled back.
+/// Must be disposed (or disposed asynchronously) to release the underlying connection.
 /// </summary>
 [PublicAPI]
 public interface ITransaction : IDisposable, IAsyncDisposable
 {
     /// <summary>
-    /// Asynchronously commits the transaction.
+    /// Asynchronously commits the transaction and makes all changes made since <see cref="IUnitOfWork.BeginTransactionAsync"/> visible.
+    /// After commit, the transaction is completed; disposal no longer performs a rollback.
     /// </summary>
-    /// <param name="cancellationToken">
-    /// A token that can be used to cancel the operation.
-    /// </param>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task CommitAsync(CancellationToken cancellationToken = default);
 }

--- a/Src/Geneirodan.Abstractions/Repositories/IUnitOfWork.cs
+++ b/Src/Geneirodan.Abstractions/Repositories/IUnitOfWork.cs
@@ -1,32 +1,32 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 
 namespace Geneirodan.Abstractions.Repositories;
 
 /// <summary>
-/// Defines an interface for unit-of-work pattern, managing transactions and saving changes.
+/// Defines the unit-of-work pattern: coordinates persistence and explicit database transactions.
+/// Use this interface to flush changes from repositories (e.g. <see cref="IRepository{TEntity, TKey}"/>) and to
+/// run multiple operations in a single transaction. In web applications, typically one unit of work is scoped per request.
 /// </summary>
 [PublicAPI]
 public interface IUnitOfWork
 {
     /// <summary>
-    /// Begins a new transaction asynchronously.
+    /// Begins a new database transaction asynchronously.
+    /// Use the returned <see cref="ITransaction"/> to commit or to let disposal roll back. Call <see cref="SaveChangesAsync"/>
+    /// before <see cref="ITransaction.CommitAsync"/> to persist changes within the transaction.
     /// </summary>
-    /// <param name="cancellationToken">
-    /// A token that can be used to cancel the operation.
-    /// </param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>
-    /// A <see cref="Task{ITransaction}"/> representing the asynchronous operation, with an <see cref="ITransaction"/> that manages the transaction.
+    /// A task that represents the asynchronous operation.<br/>
+    /// The task result is an <see cref="ITransaction"/> that must be disposed; call <see cref="ITransaction.CommitAsync"/> to commit.
     /// </returns>
     Task<ITransaction> BeginTransactionAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Saves all changes made during the current unit of work asynchronously.
+    /// Persists all changes made in the current unit of work (e.g. repository adds/updates/deletes) asynchronously.
+    /// Must be called after repository operations for changes to be written to the database.
     /// </summary>
-    /// <param name="cancellationToken">
-    /// A token that can be used to cancel the operation.
-    /// </param>
-    /// <returns>
-    /// A <see cref="Task"/> representing the asynchronous operation.
-    /// </returns>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/Src/Geneirodan.Abstractions/Repositories/PageModel.cs
+++ b/Src/Geneirodan.Abstractions/Repositories/PageModel.cs
@@ -3,46 +3,46 @@ using JetBrains.Annotations;
 namespace Geneirodan.Abstractions.Repositories;
 
 /// <summary>
-/// Represents a paginated result set for a collection of items.
+/// Represents a single page of a paginated result set.
+/// Used by query handlers and repositories to return sliced data together with page index, size, and total count
+/// so that clients can build paged UI or follow next/previous links.
 /// </summary>
-/// <typeparam name="T">
-/// The type of items contained in the paginated result.
-/// </typeparam>
+/// <typeparam name="T">The type of items contained in the paginated result.</typeparam>
 [PublicAPI]
 public record PageModel<T>
 {
     /// <summary>
-    /// The collection of items for the current page.
+    /// The collection of items for the current page (at most <see cref="PageSize"/> items).
     /// </summary>
     public required IEnumerable<T> Items { get; init; }
 
     /// <summary>
-    /// The current page number.
+    /// The current page number (1-based). Used together with <see cref="PageSize"/> to compute skip/take for the next page.
     /// </summary>
     public required int Page { get; init; }
 
     /// <summary>
-    /// The number of items per page.
+    /// The number of items per page. Determines the maximum size of <see cref="Items"/> for this page.
     /// </summary>
     public required int PageSize { get; init; }
 
     /// <summary>
-    /// The total number of items across all pages.
+    /// The total number of items across all pages. Used to compute <see cref="TotalPages"/> and to show "X of Y" in the UI.
     /// </summary>
     public required long TotalCount { get; init; }
 
     /// <summary>
-    /// Gets a value indicating whether there is a next page of items.
+    /// Gets a value indicating whether there is a next page of items after the current page.
     /// </summary>
     public bool HasNextPage => Page * PageSize < TotalCount;
 
     /// <summary>
-    /// Gets a value indicating whether there is a previous page of items.
+    /// Gets a value indicating whether there is a previous page (i.e. current page is greater than 1).
     /// </summary>
     public bool HasPrevPage => Page > 1;
 
     /// <summary>
-    /// Gets the total number of pages based on the total count of items and items per page.
+    /// Gets the total number of pages based on <see cref="TotalCount"/> and <see cref="PageSize"/> (ceiling division).
     /// </summary>
     public int TotalPages => (int)Math.Ceiling(TotalCount / (double)PageSize);
 }

--- a/Src/Geneirodan.AspNetCore/DependencyInjection.cs
+++ b/Src/Geneirodan.AspNetCore/DependencyInjection.cs
@@ -15,7 +15,7 @@ public static class DependencyInjection
     /// <summary>
     /// Registers JWT Bearer authentication as the default scheme. Configuration is bound from <paramref name="sectionName"/>.
     /// Use <paramref name="configureOptions"/> to override or add options (e.g. token validation). After this call, the HTTP context user
-    /// is populated from the Bearer token and <see cref="AddHttpUser"/> can provide <see cref="IUser"/>.
+    /// is populated from the Bearer token.
     /// </summary>
     /// <param name="services">The service collection to add the authentication services to.</param>
     /// <param name="configureOptions">Optional delegate to configure <see cref="JwtBearerOptions"/>.</param>

--- a/Src/Geneirodan.AspNetCore/DependencyInjection.cs
+++ b/Src/Geneirodan.AspNetCore/DependencyInjection.cs
@@ -50,8 +50,7 @@ public static class DependencyInjection
 
     /// <summary>
     /// Registers <see cref="IUser"/> as a scoped service implemented by <see cref="HttpUser"/>, which reads the current
-    /// HTTP context claims. Requires HTTP context accessor (and typically JWT auth via <see cref="AddJwtAuth"/>).
-    /// Handlers and authorization can then depend on <see cref="IUser"/> instead of HTTP types.
+    /// HTTP context claims. Requires HTTP context accessor and an authentication scheme (e.g. JWT or cookies) to populate the user.
     /// </summary>
     /// <param name="services">The service collection to add the user services to.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with <see cref="IUser"/> and <see cref="HttpUser"/> registered.</returns>

--- a/Src/Geneirodan.AspNetCore/DependencyInjection.cs
+++ b/Src/Geneirodan.AspNetCore/DependencyInjection.cs
@@ -1,4 +1,4 @@
-﻿using Geneirodan.Abstractions.Domain;
+using Geneirodan.Abstractions.Domain;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,18 +6,22 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Geneirodan.AspNetCore;
 
 /// <summary>
-/// Provides extension methods for configuring services in <see cref="IServiceCollection"/>.
+/// Extension methods to register ASP.NET Core and Geneirodan.AspNetCore services: JWT authentication,
+/// current user (<see cref="IUser"/>), localization, and central exception handling with problem details.
 /// </summary>
 [PublicAPI]
 public static class DependencyInjection
 {
     /// <summary>
-    /// Adds JWT authentication services to the <see cref="IServiceCollection"/> using a specified metadata address.
+    /// Registers JWT Bearer authentication as the default scheme. Configuration is bound from <paramref name="sectionName"/>.
+    /// Use <paramref name="configureOptions"/> to override or add options (e.g. token validation). After this call, the HTTP context user
+    /// is populated from the Bearer token and <see cref="AddHttpUser"/> can provide <see cref="IUser"/>.
     /// </summary>
     /// <param name="services">The service collection to add the authentication services to.</param>
-    /// <param name="configureOptions"></param>
-    /// <param name="sectionName">The section name for the JWT bearer token configuration.</param>
+    /// <param name="configureOptions">Optional delegate to configure <see cref="JwtBearerOptions"/>.</param>
+    /// <param name="sectionName">The configuration section name for JWT options. Defaults to <c>JwtAuth</c>.</param>
     /// <returns>The updated <see cref="IServiceCollection"/> with JWT authentication configured.</returns>
+    /// <remarks>When <paramref name="sectionName"/> is used, the corresponding config section must contain valid JWT options (e.g. Authority, Audience).</remarks>
     public static IServiceCollection AddJwtAuth(
         this IServiceCollection services, 
         Action<JwtBearerOptions>? configureOptions = null,
@@ -45,21 +49,24 @@ public static class DependencyInjection
     }
 
     /// <summary>
-    /// Adds HTTP implementation of <see cref="IUser"/> services to the <see cref="IServiceCollection"/>.
+    /// Registers <see cref="IUser"/> as a scoped service implemented by <see cref="HttpUser"/>, which reads the current
+    /// HTTP context claims. Requires HTTP context accessor (and typically JWT auth via <see cref="AddJwtAuth"/>).
+    /// Handlers and authorization can then depend on <see cref="IUser"/> instead of HTTP types.
     /// </summary>
     /// <param name="services">The service collection to add the user services to.</param>
-    /// <returns>The updated <see cref="IServiceCollection"/> with HTTP user service added.</returns>
+    /// <returns>The updated <see cref="IServiceCollection"/> with <see cref="IUser"/> and <see cref="HttpUser"/> registered.</returns>
     public static IServiceCollection AddHttpUser(this IServiceCollection services) =>
         services
             .AddHttpContextAccessor()
             .AddScoped<IUser, HttpUser>();
 
     /// <summary>
-    /// Adds web localization services to the <see cref="IServiceCollection"/>.
+    /// Registers request localization with the given supported cultures. The first culture in <paramref name="supportedCultures"/>
+    /// is used as the default. Use this when the API or views need to vary by <see cref="System.Globalization.CultureInfo.CurrentCulture"/>.
     /// </summary>
     /// <param name="services">The service collection to add the localization services to.</param>
-    /// <param name="supportedCultures">A list of supported cultures for localization.</param>
-    /// <returns>The updated <see cref="IServiceCollection"/> with localization services configured.</returns>
+    /// <param name="supportedCultures">The list of supported culture names (e.g. "en", "ru"). The first is the default.</param>
+    /// <returns>The updated <see cref="IServiceCollection"/> with localization and request localization configured.</returns>
     public static IServiceCollection AddWebLocalization(this IServiceCollection services,
         params string[] supportedCultures) =>
         services
@@ -71,10 +78,12 @@ public static class DependencyInjection
             );
 
     /// <summary>
-    /// Adds error handling services to the <see cref="IServiceCollection"/>.
+    /// Registers <see cref="ExceptionHandler"/> as the application's exception handler and configures problem details
+    /// so that Instance and requestId are set per request. When an unhandled exception occurs, the pipeline writes
+    /// RFC 7807 problem details and an appropriate status code (see <see cref="ExceptionHandler"/>).
     /// </summary>
     /// <param name="services">The service collection to add the error handling services to.</param>
-    /// <returns>The updated <see cref="IServiceCollection"/> with error handling services configured.</returns>
+    /// <returns>The updated <see cref="IServiceCollection"/> with exception handler and problem details configured.</returns>
     public static IServiceCollection AddErrorHandling(this IServiceCollection services) =>
         services
             .AddExceptionHandler<ExceptionHandler>()

--- a/Src/Geneirodan.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/Src/Geneirodan.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using HealthChecks.UI.Client;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Builder;
@@ -8,16 +8,20 @@ using Microsoft.AspNetCore.Routing;
 namespace Geneirodan.AspNetCore;
 
 /// <summary>
-/// Provides extension methods for <see cref="IEndpointRouteBuilder"/> to map health check endpoints
-/// with a default or specified route pattern and response writer.
+/// Extension methods for <see cref="IEndpointRouteBuilder"/> to map health-check endpoints with a JSON response writer
+/// (HealthChecks UI format). Use these when registering health checks so that the response is machine-readable and consistent.
 /// </summary>
 [PublicAPI]
 public static class EndpointRouteBuilderExtensions
 {
     /// <summary>
-    /// Maps a health check endpoint that returns a JSON response.
+    /// Maps a health check endpoint that returns a JSON response using the HealthChecks UI writer (no exception details in the response).
+    /// Call this after <c>AddHealthChecks</c> and any health check registrations. The default route is <c>/health</c>.
     /// </summary>
-    /// <inheritdoc cref="HealthCheckEndpointRouteBuilderExtensions.MapHealthChecks(IEndpointRouteBuilder, string, HealthCheckOptions?)"/>
+    /// <param name="routeBuilder">The endpoint route builder (e.g. <c>app</c> in minimal APIs).</param>
+    /// <param name="pattern">The route pattern for the health endpoint. Defaults to <c>/health</c>.</param>
+    /// <param name="options">Optional health check options; if not provided, only the response writer is set.</param>
+    /// <returns>An <see cref="IEndpointConventionBuilder"/> for further configuration.</returns>
     public static IEndpointConventionBuilder MapHealthChecksWithJsonSupport(
         this IEndpointRouteBuilder routeBuilder,
         [StringSyntax("Route"), RouteTemplate] string pattern = "/health",

--- a/Src/Geneirodan.AspNetCore/EndpointRouteBuilderExtensions.cs
+++ b/Src/Geneirodan.AspNetCore/EndpointRouteBuilderExtensions.cs
@@ -9,7 +9,7 @@ namespace Geneirodan.AspNetCore;
 
 /// <summary>
 /// Extension methods for <see cref="IEndpointRouteBuilder"/> to map health-check endpoints with a JSON response writer
-/// (HealthChecks UI format). Use these when registering health checks so that the response is machine-readable and consistent.
+/// (HealthChecks UI format) for a human-readable health summary.
 /// </summary>
 [PublicAPI]
 public static class EndpointRouteBuilderExtensions

--- a/Src/Geneirodan.AspNetCore/ExceptionHandler.cs
+++ b/Src/Geneirodan.AspNetCore/ExceptionHandler.cs
@@ -1,15 +1,27 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Geneirodan.AspNetCore;
 
-/// <inheritdoc />
+/// <summary>
+/// Central exception handler for the pipeline; converts unhandled exceptions into HTTP status codes and RFC 7807 problem details.
+/// Registered when <see cref="DependencyInjection.AddErrorHandling"/> is used. Maps exception types to status codes:
+/// <see cref="InvalidOperationException"/> and <see cref="ArgumentException"/> to 422 Unprocessable Entity;
+/// <see cref="BadHttpRequestException"/> and <see cref="FormatException"/> to 400 Bad Request; all others to 500 Internal Server Error.
+/// Writes the response via <see cref="IProblemDetailsService"/> so that middleware and filters get a consistent error shape.
+/// </summary>
 [PublicAPI]
 public class ExceptionHandler(IProblemDetailsService problemDetailsService) : IExceptionHandler
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Attempts to handle the exception by setting the response status code and writing problem details.
+    /// </summary>
+    /// <param name="httpContext">The current HTTP context.</param>
+    /// <param name="exception">The unhandled exception that occurred.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
+    /// <returns><see langword="true"/> if the exception was handled and the response was written; otherwise <see langword="false"/>.</returns>
     public virtual async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
     {
         var statusCode = exception switch

--- a/Src/Geneirodan.AspNetCore/HttpUser.cs
+++ b/Src/Geneirodan.AspNetCore/HttpUser.cs
@@ -1,18 +1,28 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 using Geneirodan.Abstractions.Domain;
 using Microsoft.AspNetCore.Http;
 
 namespace Geneirodan.AspNetCore;
 
 /// <summary>
-/// Implements the <see cref="IUser"/> interface using information from the current HTTP context.
+/// Implements <see cref="IUser"/> by reading the current HTTP context (claims principal).
+/// Registered as the scoped <see cref="IUser"/> when <see cref="DependencyInjection.AddHttpUser"/> is called.
+/// Allows MediatR handlers and authorization to depend on <see cref="IUser"/> instead of <see cref="HttpContext"/>.
 /// </summary>
 public sealed class HttpUser(IHttpContextAccessor httpContextAccessor) : IUser
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Checks whether the current request's user is in the given role, using the authentication scheme's role claims.
+    /// Returns <see langword="false"/> when there is no HTTP context or no authenticated user.
+    /// </summary>
+    /// <param name="role">The role name to check (e.g. "Admin").</param>
+    /// <returns><see langword="true"/> if the user is in the specified role; otherwise <see langword="false"/>.</returns>
     public bool IsInRole(string role) => httpContextAccessor.HttpContext?.User.IsInRole(role) ?? false;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Gets the user identifier from the <c>NameIdentifier</c> claim. Returns <see cref="Guid.Empty"/> when the user
+    /// is not authenticated or the claim is missing or invalid.
+    /// </summary>
     public Guid Id
     {
         get

--- a/Src/Geneirodan.AspNetCore/HttpUser.cs
+++ b/Src/Geneirodan.AspNetCore/HttpUser.cs
@@ -6,8 +6,7 @@ namespace Geneirodan.AspNetCore;
 
 /// <summary>
 /// Implements <see cref="IUser"/> by reading the current HTTP context (claims principal).
-/// Registered as the scoped <see cref="IUser"/> when <see cref="DependencyInjection.AddHttpUser"/> is called.
-/// Allows MediatR handlers and authorization to depend on <see cref="IUser"/> instead of <see cref="HttpContext"/>.
+/// Allows handlers and authorization to depend on <see cref="IUser"/> instead of <see cref="HttpContext"/>.
 /// </summary>
 public sealed class HttpUser(IHttpContextAccessor httpContextAccessor) : IUser
 {

--- a/Src/Geneirodan.AspNetCore/JwtBearerSecuritySchemeTransformer.cs
+++ b/Src/Geneirodan.AspNetCore/JwtBearerSecuritySchemeTransformer.cs
@@ -1,4 +1,4 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.OpenApi;
@@ -7,7 +7,9 @@ using Microsoft.OpenApi.Models;
 namespace Geneirodan.AspNetCore;
 
 /// <summary>
-/// Represents a transformer that can be used to modify an OpenAPI document to add JWT bearer security schema.
+/// OpenAPI document transformer that adds the JWT Bearer security scheme and applies it to all operations when JWT authentication is configured.
+/// Used by Swagger/OpenAPI UI so that "Authorize" uses the Bearer token. Registers the scheme in <c>document.Components.SecuritySchemes</c>
+/// and adds the security requirement to each operation so that generated clients send the Authorization header.
 /// </summary>
 [PublicAPI]
 public sealed class JwtBearerSecuritySchemeTransformer(IAuthenticationSchemeProvider authenticationSchemeProvider)
@@ -35,7 +37,12 @@ public sealed class JwtBearerSecuritySchemeTransformer(IAuthenticationSchemeProv
         ] = []
     };
 
-    /// <inheritdoc />
+    /// <summary>
+    /// Adds JWT Bearer security scheme and requirement to the OpenAPI document if the JWT Bearer authentication scheme is registered.
+    /// </summary>
+    /// <param name="document">The OpenAPI document to transform.</param>
+    /// <param name="context">The transformer context.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     public async Task TransformAsync(
         OpenApiDocument document,
         OpenApiDocumentTransformerContext context,

--- a/Src/Geneirodan.AspNetCore/ResultConverter.cs
+++ b/Src/Geneirodan.AspNetCore/ResultConverter.cs
@@ -1,4 +1,4 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -7,19 +7,20 @@ using IResult = Ardalis.Result.IResult;
 namespace Geneirodan.AspNetCore;
 
 /// <summary>
-/// Provides extension methods to convert an <see cref="Ardalis.Result.IResult"/>
-/// into an ASP.NET Core <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+/// Converts <see cref="Ardalis.Result.IResult"/> (returned by MediatR handlers) into ASP.NET Core minimal API <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+/// Use <see cref="MapResult(IResult)"/> in endpoint lambdas after sending a command or query so that Ok/NotFound/ValidationProblem
+/// and other results are written correctly. Maps <see cref="ResultStatus"/> to HTTP status codes and problem details.
 /// </summary>
 [PublicAPI]
-public static class ResultConverter 
+public static class ResultConverter
 {
     /// <summary>
-    /// Maps the given <see cref="Ardalis.Result.IResult"/>
-    /// to an appropriate ASP.NET Core <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+    /// Maps the given <see cref="Ardalis.Result.IResult"/> to the corresponding ASP.NET Core <see cref="Microsoft.AspNetCore.Http.IResult"/>.
+    /// Handles Ok, Created, NoContent, NotFound, Unauthorized, Forbidden, Invalid (validation errors), Error, Conflict, Unavailable, and CriticalError.
     /// </summary>
-    /// <param name="result">The <see cref="Ardalis.Result.IResult"/> to map.</param>
-    /// <returns>An <see cref="Microsoft.AspNetCore.Http.IResult"/> representing the HTTP response.</returns>
-    /// <exception cref="NotSupportedException">Thrown when the result status is not supported.</exception>
+    /// <param name="result">The result returned from a MediatR handler (e.g. <see cref="Result"/> or <see cref="Result{T}"/>).</param>
+    /// <returns>An <see cref="Microsoft.AspNetCore.Http.IResult"/> that writes the appropriate HTTP response for <paramref name="result"/>.</returns>
+    /// <exception cref="NotSupportedException">Thrown when <paramref name="result"/> has a <see cref="ResultStatus"/> that is not mapped to an HTTP result.</exception>
     public static Microsoft.AspNetCore.Http.IResult MapResult(this IResult result) => result.Status switch
     {
         ResultStatus.Ok => result is Result ? TypedResults.Ok() : TypedResults.Ok(result.GetValue()),

--- a/Src/Geneirodan.EntityFrameworkCore/MappingExtensions.cs
+++ b/Src/Geneirodan.EntityFrameworkCore/MappingExtensions.cs
@@ -1,34 +1,24 @@
-﻿using Geneirodan.Abstractions.Mapping;
+using Geneirodan.Abstractions.Mapping;
 using JetBrains.Annotations;
 
 namespace Geneirodan.EntityFrameworkCore;
 
 /// <summary>
-/// Provides extension methods for mapping entities or collections of entities.
+/// Extension methods for mapping <see cref="IQueryable{T}"/> to another queryable type using <see cref="IMapper{TSource, TDestination}"/>.
+/// Use when the mapper can translate the entire query (e.g. to a different entity or DTO) so that the database executes a single projected query.
 /// </summary>
 [PublicAPI]
 public static class MappingExtensions
 {
     /// <summary>
-    /// Projects a queryable collection of <typeparamref name="TSource"/>
-    /// to a queryable collection of <typeparamref name="TDestination"/>.
+    /// Projects the queryable of <typeparamref name="TSource"/> to <see cref="IQueryable{TDestination}"/> using the provided mapper.
+    /// The mapper must produce a queryable that can be executed by the provider (e.g. EF Core); execution is deferred until the query is enumerated.
     /// </summary>
-    /// <typeparam name="TSource">
-    /// The type of the source entities in the collection.
-    /// </typeparam>
-    /// <typeparam name="TDestination">
-    /// The type of the destination entities after mapping.
-    /// </typeparam>
-    /// <param name="queryable">
-    /// The queryable collection of <typeparamref name="TSource"/> entities to be mapped.
-    /// </param>
-    /// <param name="mapper">
-    /// An instance of <see cref="IMapper{TSource, TDestination}"/>
-    /// used to map the source collection to the destination collection.
-    /// </param>
-    /// <returns>
-    /// A <see cref="IQueryable{TDestination}"/> representing the mapped collection of <typeparamref name="TDestination"/> entities.
-    /// </returns>
+    /// <typeparam name="TSource">The type of the source entities in the queryable.</typeparam>
+    /// <typeparam name="TDestination">The type of the destination after mapping.</typeparam>
+    /// <param name="queryable">The source queryable to map.</param>
+    /// <param name="mapper">The mapper that converts the queryable to the destination queryable (e.g. entity to DTO projection).</param>
+    /// <returns>An <see cref="IQueryable{TDestination}"/> that, when executed, returns the mapped results.</returns>
     public static IQueryable<TDestination> ProjectTo<TSource, TDestination>(
         this IQueryable<TSource> queryable,
         IMapper<IQueryable<TSource>, IQueryable<TDestination>> mapper

--- a/Src/Geneirodan.EntityFrameworkCore/Repository.cs
+++ b/Src/Geneirodan.EntityFrameworkCore/Repository.cs
@@ -1,4 +1,4 @@
-﻿using Geneirodan.Abstractions.Domain;
+using Geneirodan.Abstractions.Domain;
 using Geneirodan.Abstractions.Repositories;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
@@ -6,18 +6,13 @@ using Microsoft.EntityFrameworkCore;
 namespace Geneirodan.EntityFrameworkCore;
 
 /// <summary>
-/// Provides an implementation of the repository pattern for managing entities in a DbContext.
+/// Entity Framework Core implementation of <see cref="IRepository{TEntity, TKey}"/> that uses a <see cref="DbContext"/> and its <see cref="DbSet{TEntity}"/>.
+/// Register as scoped (or same lifetime as the DbContext); use together with <see cref="UnitOfWork"/> so that <see cref="IUnitOfWork.SaveChangesAsync"/> persists changes.
+/// Override <see cref="FindAsync(IQueryable{TEntity}, TKey, CancellationToken)"/> in derived types to add includes or filtering.
 /// </summary>
-/// <param name="context">
-/// The <see cref="DbContext"/> instance used to interact with the database.
-/// </param>
-/// <typeparam name="TEntity">
-/// The type of the entity that the repository manages.
-/// It must implement the <see cref="IEntity{TKey}"/> interface.
-/// </typeparam>
-/// <typeparam name="TKey">
-/// The type of the primary key of the entity. It must implement <see cref="IEquatable{TKey}"/>.
-/// </typeparam>
+/// <param name="context">The DbContext that owns the <see cref="DbSet{TEntity}"/> for <typeparamref name="TEntity"/>.</param>
+/// <typeparam name="TEntity">The entity type; must be a class and implement <see cref="IEntity{TKey}"/> and be mapped in the context.</typeparam>
+/// <typeparam name="TKey">The type of the primary key; must implement <see cref="IEquatable{TKey}"/>.</typeparam>
 [PublicAPI]
 public class Repository<TEntity, TKey>(DbContext context)
     : IRepository<TEntity, TKey>
@@ -25,7 +20,7 @@ public class Repository<TEntity, TKey>(DbContext context)
     where TKey : IEquatable<TKey>
 {
     /// <summary>
-    /// The DbSet representing the collection of <typeparamref name="TEntity"/> entities in the context.
+    /// The DbSet for <typeparamref name="TEntity"/> in the context. Exposed for derived repositories that need to build custom queries.
     /// </summary>
     protected DbSet<TEntity> Set => context.Set<TEntity>();
 
@@ -33,22 +28,28 @@ public class Repository<TEntity, TKey>(DbContext context)
     public virtual Task<TEntity?> FindAsync(TKey id, CancellationToken token = default) => FindAsync(Set, id, token);
 
     /// <inheritdoc/>
-    public Task<bool> ExistsAsync(TKey id, CancellationToken token = default) => 
+    public Task<bool> ExistsAsync(TKey id, CancellationToken token = default) =>
         Set.AnyAsync(e => e.Id.Equals(id), token);
 
-    /// <inheritdoc cref="IRepository{TEntity,TKey}.FindAsync"/>
-    protected virtual async Task<TEntity?> FindAsync(IQueryable<TEntity> entities, TKey id, CancellationToken token) => 
-        await entities.FirstOrDefaultAsync(e => e.Id.Equals(id),token).ConfigureAwait(false);
+    /// <summary>
+    /// Looks up an entity by id in the given queryable. Override to add <c>Include</c> or apply filters before the lookup.
+    /// </summary>
+    /// <param name="entities">The queryable (e.g. <see cref="Set"/> or an included query).</param>
+    /// <param name="id">The entity identifier.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The entity if found; otherwise <see langword="null"/>.</returns>
+    protected virtual async Task<TEntity?> FindAsync(IQueryable<TEntity> entities, TKey id, CancellationToken token) =>
+        await entities.FirstOrDefaultAsync(e => e.Id.Equals(id), token).ConfigureAwait(false);
 
     /// <inheritdoc/>
-    public virtual Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default) => 
+    public virtual Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default) =>
         Task.FromResult(Set.Add(entity).Entity);
 
     /// <inheritdoc/>
-    public virtual Task<TEntity> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) => 
+    public virtual Task<TEntity> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) =>
         Task.FromResult(Set.Update(entity).Entity);
 
     /// <inheritdoc/>
-    public virtual Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default) => 
+    public virtual Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default) =>
         Task.FromResult(Set.Remove(entity));
 }

--- a/Src/Geneirodan.EntityFrameworkCore/UnitOfWork.cs
+++ b/Src/Geneirodan.EntityFrameworkCore/UnitOfWork.cs
@@ -1,40 +1,44 @@
-﻿using Geneirodan.Abstractions.Repositories;
+using Geneirodan.Abstractions.Repositories;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Geneirodan.EntityFrameworkCore;
 
-/// <inheritdoc />
+/// <summary>
+/// Entity Framework Core implementation of <see cref="IUnitOfWork"/> that wraps a <see cref="DbContext"/>.
+/// Register with the same lifetime as the DbContext (typically scoped). Call <see cref="SaveChangesAsync"/> after repository
+/// operations to persist changes; use <see cref="BeginTransactionAsync"/> when multiple operations must commit or roll back together.
+/// </summary>
 [PublicAPI]
 public class UnitOfWork(DbContext context) : IUnitOfWork
 {
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<ITransaction> BeginTransactionAsync(CancellationToken cancellationToken = default) =>
         new Transaction(await context.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false));
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task SaveChangesAsync(CancellationToken cancellationToken = default) =>
         await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-
-    /// <inheritdoc cref="IDbContextTransaction"/>
-    /// <remarks />
+    /// <summary>
+    /// Wraps an EF Core <see cref="IDbContextTransaction"/> so that it implements <see cref="ITransaction"/>.
+    /// Commit via <see cref="CommitAsync"/>; disposal without commit results in rollback.
+    /// </summary>
     public class Transaction(IDbContextTransaction dbContextTransaction) : ITransaction
     {
-        /// <inheritdoc cref="IDbContextTransaction.CommitAsync(CancellationToken)"/>
-        /// <remarks />
+        /// <inheritdoc/>
         public async Task CommitAsync(CancellationToken cancellationToken = default) =>
             await dbContextTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public ValueTask DisposeAsync()
         {
             GC.SuppressFinalize(this);
             return dbContextTransaction.DisposeAsync();
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public void Dispose()
         {
             GC.SuppressFinalize(this);

--- a/Src/Geneirodan.MediatR/Abstractions/ICommand.cs
+++ b/Src/Geneirodan.MediatR/Abstractions/ICommand.cs
@@ -5,19 +5,17 @@ namespace Geneirodan.MediatR.Abstractions;
 
 /// <summary>
 /// Marker and contract for a MediatR command that returns a non-generic <see cref="Result"/> (success or error, no value).
-/// Implement as a sealed record with a nested <c>Handler</c> implementing <see cref="IRequestHandler{TRequest, TResponse}"/>.
-/// Processed by the MediatR pipeline (logging, authorization, validation, exception handling) when sent via <c>ISender.Send</c>.
 /// </summary>
 /// <remarks>
 /// <seealso cref="ICommand{T}"/> — command that returns a value.<br/>
-/// <seealso cref="IQuery{T}"/> — query (read) contract with the same pipeline.
+/// <seealso cref="IQuery{T}"/> — query (read) contract.
 /// </remarks>
 [PublicAPI]
 public interface ICommand : IRequest<Result>;
 
 /// <summary>
 /// Marker and contract for a MediatR command that returns a <see cref="Result{T}"/> (success with value or error).
-/// Use when the command produces a value (e.g. created entity ID or updated resource). Same pipeline and handler pattern as <see cref="ICommand"/>.
+/// Use when the command produces a value (e.g. created entity ID or updated resource).
 /// </summary>
 /// <typeparam name="T">The type of the value returned on success (e.g. entity ID or DTO).</typeparam>
 [PublicAPI]

--- a/Src/Geneirodan.MediatR/Abstractions/ICommand.cs
+++ b/Src/Geneirodan.MediatR/Abstractions/ICommand.cs
@@ -1,17 +1,24 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
 using JetBrains.Annotations;
 
 namespace Geneirodan.MediatR.Abstractions;
 
 /// <summary>
-/// Represents a command that returns a non-generic <see cref="Result"/>.
+/// Marker and contract for a MediatR command that returns a non-generic <see cref="Result"/> (success or error, no value).
+/// Implement as a sealed record with a nested <c>Handler</c> implementing <see cref="IRequestHandler{TRequest, TResponse}"/>.
+/// Processed by the MediatR pipeline (logging, authorization, validation, exception handling) when sent via <c>ISender.Send</c>.
 /// </summary>
+/// <remarks>
+/// <seealso cref="ICommand{T}"/> — command that returns a value.<br/>
+/// <seealso cref="IQuery{T}"/> — query (read) contract with the same pipeline.
+/// </remarks>
 [PublicAPI]
 public interface ICommand : IRequest<Result>;
 
 /// <summary>
-/// Represents a command that returns a generic <see cref="Result{T}"/>.
+/// Marker and contract for a MediatR command that returns a <see cref="Result{T}"/> (success with value or error).
+/// Use when the command produces a value (e.g. created entity ID or updated resource). Same pipeline and handler pattern as <see cref="ICommand"/>.
 /// </summary>
-/// <typeparam name="T">The type of the value returned in the result.</typeparam>
+/// <typeparam name="T">The type of the value returned on success (e.g. entity ID or DTO).</typeparam>
 [PublicAPI]
 public interface ICommand<T> : IRequest<Result<T>>;

--- a/Src/Geneirodan.MediatR/Abstractions/IQuery.cs
+++ b/Src/Geneirodan.MediatR/Abstractions/IQuery.cs
@@ -6,8 +6,7 @@ namespace Geneirodan.MediatR.Abstractions;
 
 /// <summary>
 /// Marker and contract for a MediatR query that returns a <see cref="Result{T}"/> (success with data or error).
-/// Implement as a sealed record with a nested <c>Handler</c>. Use for read operations; processed by the same pipeline as commands
-/// (logging, authorization, validation, exception handling) when sent via <c>ISender.Send</c>.
+/// Use for read operations.
 /// </summary>
 /// <typeparam name="T">The type of the data returned on success (e.g. entity, DTO, or <see cref="PageModel{T}"/>).</typeparam>
 [PublicAPI]

--- a/Src/Geneirodan.MediatR/Abstractions/IQuery.cs
+++ b/Src/Geneirodan.MediatR/Abstractions/IQuery.cs
@@ -1,11 +1,14 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
+using Geneirodan.Abstractions.Repositories;
 using JetBrains.Annotations;
 
 namespace Geneirodan.MediatR.Abstractions;
 
 /// <summary>
-/// Represents a query that returns a generic <see cref="Result{T}"/>.
+/// Marker and contract for a MediatR query that returns a <see cref="Result{T}"/> (success with data or error).
+/// Implement as a sealed record with a nested <c>Handler</c>. Use for read operations; processed by the same pipeline as commands
+/// (logging, authorization, validation, exception handling) when sent via <c>ISender.Send</c>.
 /// </summary>
-/// <typeparam name="T">The type of the value returned in the result.</typeparam>
+/// <typeparam name="T">The type of the data returned on success (e.g. entity, DTO, or <see cref="PageModel{T}"/>).</typeparam>
 [PublicAPI]
 public interface IQuery<T> : IRequest<Result<T>>;

--- a/Src/Geneirodan.MediatR/Attributes/AuthorizeAttribute.cs
+++ b/Src/Geneirodan.MediatR/Attributes/AuthorizeAttribute.cs
@@ -1,9 +1,12 @@
+using Geneirodan.Abstractions.Domain;
+using Geneirodan.MediatR.Behaviors;
+
 namespace Geneirodan.MediatR.Attributes;
 
 /// <summary>
 /// Applied to a request type (command or query) to enforce authorization in the MediatR pipeline.
-/// <see cref="Geneirodan.MediatR.Behaviors.AuthorizationBehavior{TRequest, TResponse}"/> reads this attribute: when present,
-/// the current user (<see cref="Geneirodan.Abstractions.Domain.IUser"/>) must be authenticated; when <see cref="Roles"/> is set, the user must be in at least one of the roles.
+/// <see cref="AuthorizationBehavior{TRequest, TResponse}"/> reads this attribute: when present,
+/// the current user (<see cref="IUser"/>) must be authenticated; when <see cref="Roles"/> is set, the user must be in at least one of the roles.
 /// Can be applied multiple times to the same class.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
@@ -16,7 +19,7 @@ public sealed class AuthorizeAttribute : Attribute
 
     /// <summary>
     /// Comma-delimited list of role names that are allowed to execute the request. If empty, only authentication is required.
-    /// The user must be in at least one of these roles (via <see cref="Geneirodan.Abstractions.Domain.IUser.IsInRole"/>).
+    /// The user must be in at least one of these roles (via <see cref="IUser.IsInRole"/>).
     /// </summary>
     public string Roles { get; init; } = string.Empty;
 }

--- a/Src/Geneirodan.MediatR/Attributes/AuthorizeAttribute.cs
+++ b/Src/Geneirodan.MediatR/Attributes/AuthorizeAttribute.cs
@@ -1,19 +1,22 @@
 namespace Geneirodan.MediatR.Attributes;
 
 /// <summary>
-/// Specifies authorization requirements for a class.
-/// This attribute can be applied multiple times to the same class to enforce different authorization rules.
+/// Applied to a request type (command or query) to enforce authorization in the MediatR pipeline.
+/// <see cref="Geneirodan.MediatR.Behaviors.AuthorizationBehavior{TRequest, TResponse}"/> reads this attribute: when present,
+/// the current user (<see cref="Geneirodan.Abstractions.Domain.IUser"/>) must be authenticated; when <see cref="Roles"/> is set, the user must be in at least one of the roles.
+/// Can be applied multiple times to the same class.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public sealed class AuthorizeAttribute : Attribute
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="AuthorizeAttribute"/> class. 
+    /// Initializes a new instance of the <see cref="AuthorizeAttribute"/> class with no roles (authenticated user only).
     /// </summary>
     public AuthorizeAttribute() { }
 
     /// <summary>
-    /// Gets or sets a comma-delimited list of roles that are allowed to access the resource.
+    /// Comma-delimited list of role names that are allowed to execute the request. If empty, only authentication is required.
+    /// The user must be in at least one of these roles (via <see cref="Geneirodan.Abstractions.Domain.IUser.IsInRole"/>).
     /// </summary>
     public string Roles { get; init; } = string.Empty;
 }

--- a/Src/Geneirodan.MediatR/Behaviors/AuthorizationBehavior.cs
+++ b/Src/Geneirodan.MediatR/Behaviors/AuthorizationBehavior.cs
@@ -20,7 +20,14 @@ public sealed class AuthorizationBehavior<TRequest, TResponse>(IUser user) : IPi
     where TRequest : notnull
     where TResponse : Result
 {
-    /// <inheritdoc/>
+    /// <summary>
+    /// If <paramref name="request"/> type has no <see cref="AuthorizeAttribute"/>, proceeds to the handler. Otherwise ensures the current <see cref="IUser"/>
+    /// is authenticated (Id is not empty) and, if roles are specified, that the user is in at least one of the roles; otherwise returns Unauthorized or Forbidden.
+    /// </summary>
+    /// <param name="request">The command or query being handled.</param>
+    /// <param name="next">The next delegate in the pipeline.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The response from the handler or an unauthorized/forbidden result.</returns>
     public async Task<TResponse> Handle(
         TRequest request,
         RequestHandlerDelegate<TResponse> next,

--- a/Src/Geneirodan.MediatR/Behaviors/LoggingPreProcessor.cs
+++ b/Src/Geneirodan.MediatR/Behaviors/LoggingPreProcessor.cs
@@ -1,4 +1,4 @@
-﻿using Geneirodan.Abstractions.Domain;
+using Geneirodan.Abstractions.Domain;
 using MediatR.Pipeline;
 using Microsoft.Extensions.Logging;
 using Serilog.Context;
@@ -6,21 +6,24 @@ using Serilog.Context;
 namespace Geneirodan.MediatR.Behaviors;
 
 /// <summary>
-/// A pipeline behavior that logs information about incoming requests before they are processed.
-/// It logs the name of the request, the user ID, and the details of the request itself.
+/// MediatR request pre-processor that logs each incoming request before the pipeline runs.
+/// Logs the request type name and, when <see cref="IUser"/> is available and authenticated, the user ID.
+/// Request payload is pushed to Serilog's log context so that structured logging can capture it.
 /// </summary>
-/// <typeparam name="TRequest">
-/// The type of the request being processed. This should be a non-nullable type.
-/// </typeparam>
+/// <typeparam name="TRequest">The type of the request (command or query) being processed.</typeparam>
 public sealed partial class LoggingPreProcessor<TRequest>(ILogger<TRequest> logger) : IRequestPreProcessor<TRequest>
     where TRequest : notnull
 {
     private readonly IUser? _user;
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Constructor used when <see cref="IUser"/> is registered; allows logging the current user ID.
+    /// </summary>
     public LoggingPreProcessor(ILogger<TRequest> logger, IUser? user) : this(logger) => _user = user;
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Logs the request name and optional user ID, then completes so that the pipeline continues.
+    /// </summary>
     public Task Process(TRequest request, CancellationToken cancellationToken)
     {
         var requestName = typeof(TRequest).Name;

--- a/Src/Geneirodan.MediatR/Behaviors/UnhandledExceptionBehavior.cs
+++ b/Src/Geneirodan.MediatR/Behaviors/UnhandledExceptionBehavior.cs
@@ -1,23 +1,22 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
 using Microsoft.Extensions.Logging;
 
 namespace Geneirodan.MediatR.Behaviors;
 
 /// <summary>
-/// A pipeline behavior that catches and logs any unhandled exceptions thrown during request processing.
-/// This behavior ensures that any unhandled exceptions are logged before being rethrown to be handled elsewhere in the application.
+/// Pipeline behavior that catches any exception thrown by the handler (or inner behaviors), logs it with the request name,
+/// then rethrows so that the ASP.NET Core exception handler (or host) can convert it to a response. Does not convert
+/// exceptions to <see cref="Result"/>; use handler try/catch or validation/authorization for that.
 /// </summary>
-/// <typeparam name="TRequest">
-/// The type of the request being processed. This should be a non-nullable type.
-/// </typeparam>
-/// <typeparam name="TResponse">
-/// The type of the response that will be returned after handling the request. This is typically a <see cref="Result"/> type.
-/// </typeparam>
-public sealed partial class UnhandledExceptionBehavior<TRequest, TResponse>(ILogger<TRequest> logger) 
+/// <typeparam name="TRequest">The type of the request being processed.</typeparam>
+/// <typeparam name="TResponse">The type of the response (e.g. <see cref="Result"/> or <see cref="Result{T}"/>).</typeparam>
+public sealed partial class UnhandledExceptionBehavior<TRequest, TResponse>(ILogger<TRequest> logger)
     : IPipelineBehavior<TRequest, TResponse>
     where TRequest : notnull
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Invokes the next delegate; on exception, logs and rethrows.
+    /// </summary>
     public async Task<TResponse> Handle(TRequest request, RequestHandlerDelegate<TResponse> next, CancellationToken cancellationToken)
     {
         try

--- a/Src/Geneirodan.MediatR/Behaviors/ValidationBehavior.cs
+++ b/Src/Geneirodan.MediatR/Behaviors/ValidationBehavior.cs
@@ -1,26 +1,24 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
 using Ardalis.Result.FluentValidation;
 using FluentValidation;
 
 namespace Geneirodan.MediatR.Behaviors;
 
 /// <summary>
-/// A pipeline behavior that performs request validation before passing it to the handler.
-/// This behavior validates the request using a collection of validators and returns an invalid result
-/// if any validation errors are found. Otherwise, it proceeds to the next step in the pipeline.
+/// Pipeline behavior that runs all FluentValidation validators registered for <typeparamref name="TRequest"/> before the handler.
+/// If any validator fails, returns an <see cref="Ardalis.Result.ResultStatus.Invalid"/> result with the validation errors
+/// via <see cref="DynamicResults.Invalid{TResponse}"/>; otherwise calls the next delegate. Validators are resolved from the container.
 /// </summary>
-/// <typeparam name="TRequest">
-/// The type of the request being processed. It is a non-nullable type that represents the request.
-/// </typeparam>
-/// <typeparam name="TResponse">
-/// The type of the response returned by the request handler. It must be a result type that can encapsulate validation errors.
-/// </typeparam>
+/// <typeparam name="TRequest">The type of the request (command or query) to validate.</typeparam>
+/// <typeparam name="TResponse">The response type; must implement <see cref="IResult"/> so that validation errors can be returned.</typeparam>
 public sealed class ValidationBehavior<TRequest, TResponse>(IEnumerable<IValidator<TRequest>> validators)
     : IPipelineBehavior<TRequest, TResponse>
     where TRequest : IRequest<TResponse>
     where TResponse : class, IResult
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Runs all validators for the request; if valid, proceeds to the handler; otherwise returns an invalid result with errors.
+    /// </summary>
     public async Task<TResponse> Handle(
         TRequest request,
         RequestHandlerDelegate<TResponse> next,

--- a/Src/Geneirodan.MediatR/Behaviors/ValidationBehavior.cs
+++ b/Src/Geneirodan.MediatR/Behaviors/ValidationBehavior.cs
@@ -6,8 +6,8 @@ namespace Geneirodan.MediatR.Behaviors;
 
 /// <summary>
 /// Pipeline behavior that runs all FluentValidation validators registered for <typeparamref name="TRequest"/> before the handler.
-/// If any validator fails, returns an <see cref="Ardalis.Result.ResultStatus.Invalid"/> result with the validation errors
-/// via <see cref="DynamicResults.Invalid{TResponse}"/>; otherwise calls the next delegate. Validators are resolved from the container.
+/// If any validator fails, returns an <see cref="Ardalis.Result.ResultStatus.Invalid"/> result with the validation errors;
+/// otherwise calls the next delegate. Validators are resolved from the container.
 /// </summary>
 /// <typeparam name="TRequest">The type of the request (command or query) to validate.</typeparam>
 /// <typeparam name="TResponse">The response type; must implement <see cref="IResult"/> so that validation errors can be returned.</typeparam>

--- a/Src/Geneirodan.MediatR/DependencyInjection.cs
+++ b/Src/Geneirodan.MediatR/DependencyInjection.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+using System.Reflection;
+using Geneirodan.MediatR.Abstractions;
 using Geneirodan.MediatR.Behaviors;
 using Geneirodan.MediatR.Options;
 using JetBrains.Annotations;
@@ -8,27 +9,29 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Geneirodan.MediatR;
 
 /// <summary>
-/// Provides extension methods for registering MediatR pipeline behaviors and options in the <see cref="IServiceCollection"/>.
+/// Extension methods to register MediatR and the Geneirodan.MediatR pipeline (logging, authorization, validation, exception handling).
+/// Call <see cref="AddMediatRPipeline(IServiceCollection, Assembly[])"/> or the overload with <see cref="MediatRPipelineOptions"/> from the application startup.
+/// Pass the assemblies that contain <see cref="ICommand"/> / <see cref="IQuery{T}"/> and their handlers.
 /// </summary>
 [PublicAPI]
 public static class DependencyInjection
 {
     /// <summary>
-    /// Registers the MediatR pipeline behaviors with default options.
+    /// Registers MediatR and the pipeline behaviors with default options (all behaviors enabled). Request and handler types are discovered from the given assemblies.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to add the pipeline behaviors to.</param>
-    /// <param name="assemblies">The assemblies that contain MediatR request and handler types.</param>
-    /// <returns>The updated <see cref="IServiceCollection"/> with MediatR pipeline behaviors added.</returns>
+    /// <param name="services">The service collection to add MediatR and pipeline behaviors to.</param>
+    /// <param name="assemblies">The assemblies to scan for request and handler types (e.g. <c>Assembly.GetExecutingAssembly()</c>).</param>
+    /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddMediatRPipeline(this IServiceCollection services, params Assembly[] assemblies)
         => services.AddMediatRPipeline(new MediatRPipelineOptions(), assemblies);
 
     /// <summary>
-    /// Registers the MediatR pipeline behaviors with custom options.
+    /// Registers MediatR and the pipeline behaviors with the given options. Use <paramref name="options"/> to disable logging, authorization, validation, or exception handling.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to add the pipeline behaviors to.</param>
-    /// <param name="options">The configuration options for the MediatR pipeline behaviors.</param>
-    /// <param name="assemblies">The assemblies that contain MediatR request and handler types.</param>
-    /// <returns>The updated <see cref="IServiceCollection"/> with MediatR pipeline behaviors added.</returns>
+    /// <param name="services">The service collection to add MediatR and pipeline behaviors to.</param>
+    /// <param name="options">Options that control which pipeline behaviors are registered.</param>
+    /// <param name="assemblies">The assemblies to scan for request and handler types.</param>
+    /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddMediatRPipeline(
         this IServiceCollection services,
         MediatRPipelineOptions options,

--- a/Src/Geneirodan.MediatR/Options/MediatRPipelineOptions.cs
+++ b/Src/Geneirodan.MediatR/Options/MediatRPipelineOptions.cs
@@ -1,35 +1,35 @@
+using Geneirodan.MediatR.Attributes;
+using Geneirodan.MediatR.Behaviors;
 using JetBrains.Annotations;
 
 namespace Geneirodan.MediatR.Options;
 
 /// <summary>
-/// Represents configuration options for controlling which pipeline behaviors are enabled or disabled
-/// in the MediatR request processing pipeline.
+/// Options passed to <c>DependencyInjection.AddMediatRPipeline</c> to enable or disable each pipeline behavior.
+/// Order of execution when enabled: logging (pre-processor), then authorization, validation, unhandled exception handling, then handler.
 /// </summary>
 [PublicAPI]
 public sealed record MediatRPipelineOptions
 {
     /// <summary>
-    /// Indicates whether the authorization behavior should be applied in the MediatR pipeline.
-    /// Defaults to <see langword="true"/>.
+    /// When <see langword="true"/>, <see cref="AuthorizationBehavior{TRequest,TResponse}"/> runs before the handler and enforces
+    /// <see cref="AuthorizeAttribute"/> and role requirements using <see cref="Geneirodan.Abstractions.Domain.IUser"/>.
     /// </summary>
     public bool UseAuthorization { get; init; } = true;
 
     /// <summary>
-    /// Indicates whether the logging behavior should be applied in the MediatR pipeline.
-    /// Defaults to <see langword="true"/>.
+    /// When <see langword="true"/>, <see cref="LoggingPreProcessor{TRequest}"/> runs first and logs the request (and user ID when available).
     /// </summary>
     public bool UseLogging { get; init; } = true;
 
     /// <summary>
-    /// Indicates whether the unhandled exception handling behavior should be applied in the MediatR pipeline.
-    /// Defaults to <see langword="true"/>.
+    /// When <see langword="true"/>, <see cref="UnhandledExceptionBehavior{TRequest,TResponse}"/> wraps the handler and logs any exception before rethrowing.
     /// </summary>
     public bool UseExceptions { get; init; } = true;
 
     /// <summary>
-    /// Indicates whether the validation behavior should be applied in the MediatR pipeline.
-    /// Defaults to <see langword="true"/>.
+    /// When <see langword="true"/>, <see cref="ValidationBehavior{TRequest,TResponse}"/> runs FluentValidation validators for the request
+    /// and returns a validation result without calling the handler if validation fails.
     /// </summary>
     public bool UseValidation { get; init; } = true;
 }

--- a/Src/Geneirodan.MediatR/Options/MediatRPipelineOptions.cs
+++ b/Src/Geneirodan.MediatR/Options/MediatRPipelineOptions.cs
@@ -1,3 +1,4 @@
+using Geneirodan.Abstractions.Domain;
 using Geneirodan.MediatR.Attributes;
 using Geneirodan.MediatR.Behaviors;
 using JetBrains.Annotations;
@@ -13,7 +14,7 @@ public sealed record MediatRPipelineOptions
 {
     /// <summary>
     /// When <see langword="true"/>, <see cref="AuthorizationBehavior{TRequest,TResponse}"/> runs before the handler and enforces
-    /// <see cref="AuthorizeAttribute"/> and role requirements using <see cref="Geneirodan.Abstractions.Domain.IUser"/>.
+    /// <see cref="AuthorizeAttribute"/> and role requirements using <see cref="IUser"/>.
     /// </summary>
     public bool UseAuthorization { get; init; } = true;
 

--- a/Src/Geneirodan.Observability/DependencyInjection.cs
+++ b/Src/Geneirodan.Observability/DependencyInjection.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +15,8 @@ using static Serilog.Sinks.OpenTelemetry.IncludedData;
 namespace Geneirodan.Observability;
 
 /// <summary>
-/// A static class for registering and configuring observability-related services, such as OpenTelemetry and Serilog.
+/// Extension methods to register OpenTelemetry (metrics and tracing) and Serilog with OTLP export.
+/// When the OTLP endpoint is not configured (<c>OTEL_EXPORTER_OTLP_ENDPOINT</c>), OpenTelemetry registration is skipped; Serilog still configures console and any sinks from configuration.
 /// </summary>
 [PublicAPI]
 public static class DependencyInjection
@@ -23,13 +24,14 @@ public static class DependencyInjection
     private const string OtelEndpointName = "OTEL_EXPORTER_OTLP_ENDPOINT";
 
     /// <summary>
-    /// Adds OpenTelemetry services to the provided <see cref="IServiceCollection"/> for collecting metrics and tracing.
+    /// Registers OpenTelemetry metrics and tracing with OTLP exporter if <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is set in configuration.
+    /// Binds <see cref="OpenTelemetrySettings"/> from the specified config section and enables instrumentation (AspNetCore, Http, EF Core, runtime) and meters as configured.
+    /// Service name is taken from configuration or the entry assembly name.
     /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> to register services with.</param>
-    /// <param name="configuration">The configuration instance containing the OpenTelemetry settings.</param>
-    /// <param name="sectionName">The section name in the configuration to bind OpenTelemetry settings. Defaults to "OpenTelemetry".</param>
-    /// <returns>The updated <see cref="IServiceCollection"/> with OpenTelemetry services added.</returns>
-
+    /// <param name="services">The service collection to register OpenTelemetry with.</param>
+    /// <param name="configuration">The configuration that contains the OTLP endpoint and the OpenTelemetry section.</param>
+    /// <param name="sectionName">The configuration section name for <see cref="OpenTelemetrySettings"/>. Defaults to <c>OpenTelemetry</c>.</param>
+    /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection AddSharedOpenTelemetry(
         this IServiceCollection services,
         IConfiguration configuration,
@@ -81,10 +83,12 @@ public static class DependencyInjection
     }
 
     /// <summary>
-    /// Configures Serilog logging for the application, including OpenTelemetry integration.
+    /// Configures Serilog to read from host configuration and services, enriches with log context and application name,
+    /// writes to console and (when <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is set) to OpenTelemetry via OTLP gRPC with trace/span context.
+    /// Call this on the host builder before building so that startup and pipeline use Serilog.
     /// </summary>
-    /// <param name="builder">The <see cref="IHostApplicationBuilder"/> to configure.</param>
-    /// <returns>The updated <see cref="IHostApplicationBuilder"/> with Serilog configured.</returns>
+    /// <param name="builder">The host application builder (e.g. <c>WebApplication.CreateBuilder(args)</c>).</param>
+    /// <returns>The updated <see cref="IHostApplicationBuilder"/>.</returns>
     public static IHostApplicationBuilder AddSerilog(this IHostApplicationBuilder builder)
     {
         var serviceName = builder.Configuration.GetServiceName();

--- a/Src/Geneirodan.Observability/OpenTelemetrySettings.cs
+++ b/Src/Geneirodan.Observability/OpenTelemetrySettings.cs
@@ -1,26 +1,26 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 
 namespace Geneirodan.Observability;
 
 /// <summary>
-/// Represents the settings for OpenTelemetry configuration.
+/// Configuration for OpenTelemetry metrics and tracing. Bound from the <c>OpenTelemetry</c> config section when
+/// <see cref="DependencyInjection.AddSharedOpenTelemetry"/> is used. When a section is <see langword="null"/>, that signal is not registered.
 /// </summary>
 [PublicAPI]
 public sealed record OpenTelemetrySettings
 {
     /// <summary>
-    /// Gets or sets the metrics-related configuration settings.
-    /// 
+    /// When set, configures which metrics instrumentation and meters are enabled and exported via OTLP.
     /// </summary>
     public MetricsSettings? Metrics { get; init; }
 
     /// <summary>
-    /// Gets or sets the tracing-related configuration settings.
+    /// When set, configures which tracing instrumentation is enabled (AspNetCore, HttpClient, EF Core) and exports spans via OTLP.
     /// </summary>
     public TracingSettings? Tracing { get; init; }
 
     /// <summary>
-    /// Represents the settings for OpenTelemetry metrics instrumentation.
+    /// Options for OpenTelemetry metrics: which instrumentations to enable and which custom meters to add.
     /// </summary>
     public sealed record MetricsSettings
     {
@@ -46,7 +46,7 @@ public sealed record OpenTelemetrySettings
     }
 
     /// <summary>
-    /// Represents the settings for OpenTelemetry tracing instrumentation.
+    /// Options for OpenTelemetry tracing: which instrumentations (AspNetCore, HTTP client, EF Core) to enable.
     /// </summary>
     public sealed record TracingSettings
     {

--- a/Tests/Geneirodan.EntityFrameworkCore.Tests/ApiFactory.cs
+++ b/Tests/Geneirodan.EntityFrameworkCore.Tests/ApiFactory.cs
@@ -1,4 +1,4 @@
-﻿using Geneirodan.Abstractions.Repositories;
+using Geneirodan.Abstractions.Repositories;
 using Geneirodan.SampleApi;
 using Geneirodan.SampleApi.Persistence;
 using JetBrains.Annotations;
@@ -10,6 +10,10 @@ using Testcontainers.PostgreSql;
 
 namespace Geneirodan.EntityFrameworkCore.Tests;
 
+/// <summary>
+/// Web application factory for integration tests. Uses Testcontainers to run a PostgreSQL instance and configures
+/// the sample API to use it for <see cref="ApplicationContext"/>, with <see cref="IRepository{TEntity, TKey}"/> and <see cref="IUnitOfWork"/> registered.
+/// </summary>
 [UsedImplicitly]
 public sealed class ApiFactory : WebApplicationFactory<IApiMarker>, IAsyncLifetime
 {

--- a/Tests/Geneirodan.EntityFrameworkCore.Tests/IntegrationTest.cs
+++ b/Tests/Geneirodan.EntityFrameworkCore.Tests/IntegrationTest.cs
@@ -1,10 +1,14 @@
-﻿using Geneirodan.SampleApi;
+using Geneirodan.SampleApi;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Geneirodan.EntityFrameworkCore.Tests;
 
+/// <summary>
+/// Base class for integration tests that use the sample API host (<see cref="ApiFactory"/>) and a scoped DbContext.
+/// Provides <see cref="Context"/> for direct DB access and <see cref="Scope"/> for resolving services (e.g. repository, unit of work).
+/// </summary>
 public abstract class IntegrationTest : IClassFixture<ApiFactory>, IDisposable
 {
     protected IntegrationTest(ApiFactory factory)

--- a/Tests/Geneirodan.EntityFrameworkCore.Tests/RepositoryTests.cs
+++ b/Tests/Geneirodan.EntityFrameworkCore.Tests/RepositoryTests.cs
@@ -1,4 +1,4 @@
-﻿using Geneirodan.Abstractions.Repositories;
+using Geneirodan.Abstractions.Repositories;
 using Geneirodan.SampleApi.Domain;
 using Geneirodan.SampleApi.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -7,6 +7,10 @@ using Shouldly;
 
 namespace Geneirodan.EntityFrameworkCore.Tests;
 
+/// <summary>
+/// Integration tests for <see cref="Geneirodan.EntityFrameworkCore.Repository{TEntity, TKey}"/> and <see cref="Geneirodan.EntityFrameworkCore.UnitOfWork"/>
+/// using the sample API's <see cref="ApplicationContext"/> and <see cref="DomainEntity"/>.
+/// </summary>
 public sealed class RepositoryTests : IntegrationTest, IAsyncDisposable
 {
     private IRepository<DomainEntity, int> _repository;

--- a/Tests/Geneirodan.EntityFrameworkCore.Tests/RepositoryTests.cs
+++ b/Tests/Geneirodan.EntityFrameworkCore.Tests/RepositoryTests.cs
@@ -1,4 +1,5 @@
 using Geneirodan.Abstractions.Repositories;
+using Geneirodan.EntityFrameworkCore;
 using Geneirodan.SampleApi.Domain;
 using Geneirodan.SampleApi.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -8,7 +9,7 @@ using Shouldly;
 namespace Geneirodan.EntityFrameworkCore.Tests;
 
 /// <summary>
-/// Integration tests for <see cref="Geneirodan.EntityFrameworkCore.Repository{TEntity, TKey}"/> and <see cref="Geneirodan.EntityFrameworkCore.UnitOfWork"/>
+/// Integration tests for <see cref="Repository{TEntity, TKey}"/> and <see cref="UnitOfWork"/>
 /// using the sample API's <see cref="ApplicationContext"/> and <see cref="DomainEntity"/>.
 /// </summary>
 public sealed class RepositoryTests : IntegrationTest, IAsyncDisposable

--- a/Tests/Geneirodan.MediatR.Tests/ApiFactory.cs
+++ b/Tests/Geneirodan.MediatR.Tests/ApiFactory.cs
@@ -1,4 +1,4 @@
-﻿using Geneirodan.Abstractions.Domain;
+using Geneirodan.Abstractions.Domain;
 using Geneirodan.SampleApi;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Hosting;
@@ -9,6 +9,10 @@ using Serilog;
 
 namespace Geneirodan.MediatR.Tests;
 
+/// <summary>
+/// Web application factory for MediatR pipeline tests. Hosts the sample API and replaces <see cref="IUser"/> with a mock
+/// so that authorization and logging behaviors can be tested with a controlled user.
+/// </summary>
 [UsedImplicitly]
 public sealed class ApiFactory : WebApplicationFactory<IApiMarker>
 {

--- a/Tests/Geneirodan.MediatR.Tests/Behaviors/LoggingPreProcessorTests.cs
+++ b/Tests/Geneirodan.MediatR.Tests/Behaviors/LoggingPreProcessorTests.cs
@@ -1,4 +1,5 @@
-﻿using Geneirodan.Abstractions.Domain;
+using System.Globalization;
+using Geneirodan.Abstractions.Domain;
 using Geneirodan.MediatR.Behaviors;
 using Geneirodan.SampleApi.Application.Commands;
 using JetBrains.Annotations;
@@ -29,7 +30,7 @@ public sealed class LoggingPreProcessorTests(ApiFactory factory) : PipelineTest(
             entry.ShouldNotBeNull();
             entry.Properties.ShouldContainKeyAndValue("RequestName", new ScalarValue(nameof(Command)));
             entry.Properties.ShouldContainKey("Request");
-            entry.Properties["Request"].ToString().ShouldBeEquivalentTo("Command { ShouldFail: False }");
+            Convert.ToString(entry.Properties["Request"], CultureInfo.InvariantCulture).ShouldBeEquivalentTo("Command { ShouldFail: False }");
         }
     }
 
@@ -52,7 +53,7 @@ public sealed class LoggingPreProcessorTests(ApiFactory factory) : PipelineTest(
             entry.Properties.ShouldContainKeyAndValue("RequestName", new ScalarValue(nameof(Command)));
             entry.Properties.ShouldContainKeyAndValue("UserId", new ScalarValue(userId));
             entry.Properties.ShouldContainKey("Request");
-            entry.Properties["Request"].ToString().ShouldBeEquivalentTo("Command { ShouldFail: False }");
+            Convert.ToString(entry.Properties["Request"], CultureInfo.InvariantCulture).ShouldBeEquivalentTo("Command { ShouldFail: False }");
         }
     }
 }

--- a/Tests/Geneirodan.MediatR.Tests/PipelineTest.cs
+++ b/Tests/Geneirodan.MediatR.Tests/PipelineTest.cs
@@ -3,6 +3,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Geneirodan.MediatR.Tests;
 
+/// <summary>
+/// Base class for tests that exercise the MediatR pipeline (commands/queries and behaviors) using the sample API host.
+/// Provides <see cref="Sender"/> to send requests and <see cref="Scope"/> for resolving services.
+/// </summary>
 public abstract class PipelineTest : IClassFixture<ApiFactory>, IDisposable
 {
     protected readonly ISender Sender;


### PR DESCRIPTION
- **Abstractions, AspNetCore, EntityFrameworkCore, MediatR, Observability, Sample, Tests:**
  Refined XML documentation to a three-level model: type-level summaries explain architectural role;
  non-trivial methods get one sentence for non-obvious contracts (e.g. `IRepository.FindAsync` returns
  `null` on not found, does not throw); trivial methods and implementations use `/// <inheritdoc/>` only.
  Removed MSDN-style `<param>`/`<returns>` padding. Sample API pipeline tutorials moved to README.

  No behavior changes; all 22 tests pass.