### PR TITLE
Refine XML docs: three-level rule (IRepository, Sample commands)

### DIFF
--- a/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
+++ b/Sample/Geneirodan.SampleApi/Application/Commands/Command.cs
@@ -1,4 +1,4 @@
-﻿using Ardalis.Result;
+using Ardalis.Result;
 using FluentValidation;
 using Geneirodan.MediatR.Abstractions;
 using JetBrains.Annotations;
@@ -6,8 +6,13 @@ using MediatR;
 
 namespace Geneirodan.SampleApi.Application.Commands;
 
+/// <summary>
+/// Sample command used by tests and documentation to exercise the MediatR pipeline and exception handling.
+/// </summary>
+/// <param name="ShouldFail">When <see langword="true"/>, the handler throws; otherwise returns <see cref="Result.Success"/>.</param>
 public sealed record Command(bool ShouldFail) : ICommand
 {
+    /// <inheritdoc/>
     public sealed class Handler : IRequestHandler<Command, Result>
     {
         public Task<Result> Handle(Command request, CancellationToken cancellationToken) =>
@@ -15,8 +20,13 @@ public sealed record Command(bool ShouldFail) : ICommand
     }
 }
 
+/// <summary>
+/// Sample command that demonstrates FluentValidation before the handler runs.
+/// </summary>
+/// <param name="Email">The email to validate; must be non-empty and a valid email address format.</param>
 public sealed record ValidatedCommand(string Email) : ICommand
 {
+    /// <inheritdoc/>
     public sealed class Handler : IRequestHandler<ValidatedCommand, Result>
     {
         public Task<Result> Handle(ValidatedCommand request, CancellationToken cancellationToken) =>

--- a/Src/Geneirodan.Abstractions/Repositories/IRepository.cs
+++ b/Src/Geneirodan.Abstractions/Repositories/IRepository.cs
@@ -5,88 +5,29 @@ namespace Geneirodan.Abstractions.Repositories;
 /// <summary>
 /// Defines the contract for a repository that manages entities of type <typeparamref name="TEntity"/>
 /// with a primary key of type <typeparamref name="TKey"/>.
+/// Repositories abstract persistence and are used together with <see cref="IUnitOfWork"/> for transactional
+/// operations. The concrete implementation is provided by the Geneirodan.EntityFrameworkCore package.
 /// </summary>
-/// <typeparam name="TEntity">
-/// The type of the entity that the repository manages. It must implement the <see cref="IEntity{TKey}"/> interface.
-/// </typeparam>
-/// <typeparam name="TKey">
-/// The type of the primary key of the entity. It must implement <see cref="IEquatable{TKey}"/>.
-/// </typeparam>
+/// <remarks>
+/// <seealso cref="IUnitOfWork"/> — use together for transactional persistence.<br/>
+/// <seealso cref="IEntity{TKey}"/> — <typeparamref name="TEntity"/> must implement this interface.
+/// </remarks>
+/// <typeparam name="TEntity">The type of the entity that the repository manages.</typeparam>
+/// <typeparam name="TKey">The type of the primary key of the entity; must implement <see cref="IEquatable{TKey}"/>.</typeparam>
 public interface IRepository<TEntity, in TKey>
     where TEntity : IEntity<TKey>
     where TKey : IEquatable<TKey>
 {
     /// <summary>
-    /// Asynchronously retrieves an entity by its identifier.
+    /// Looks up an entity by identifier and returns <see langword="null"/> if it does not exist instead of throwing.
     /// </summary>
-    /// <param name="id">
-    /// The identifier of the entity to retrieve.
-    /// </param>
-    /// <param name="token">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is the entity with the specified identifier, or <see langword="null"/> if no entity is found.
-    /// </returns>
     Task<TEntity?> FindAsync(TKey id, CancellationToken token = default);
 
-    /// <summary>
-    /// Asynchronously determines whether an entity with the specified identifier exists.
-    /// </summary>
-    /// <param name="id">
-    /// The identifier of the entity to check for existence.
-    /// </param>
-    /// <param name="token">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is <see langword="true"/> if an entity with the specified identifier exists; otherwise, <see langword="false"/>.
-    /// </returns>
     Task<bool> ExistsAsync(TKey id, CancellationToken token = default);
 
-    /// <summary>
-    /// Asynchronously adds a new entity to the repository.
-    /// </summary>
-    /// <param name="entity">
-    /// The entity to add.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is the added entity.
-    /// </returns>
     Task<TEntity> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Asynchronously updates an existing entity in the repository.
-    /// </summary>
-    /// <param name="entity">
-    /// The entity to update.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.<br/>
-    /// The task result is the updated entity.
-    /// </returns>
     Task<TEntity> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
 
-    /// <summary>
-    /// Asynchronously deletes an entity from the repository.
-    /// </summary>
-    /// <param name="entity">
-    /// The entity to delete.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A <see cref="CancellationToken"/> to observe while waiting for the task to complete.
-    /// </param>
-    /// <returns>
-    /// A task that represents the asynchronous operation.
-    /// </returns>
     Task DeleteAsync(TEntity entity, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
Applies the three-level documentation rule:
- **IRepository:** Type-level summary + remarks; only `FindAsync` has a one-line summary (guarantees `null` when not found, does not throw). Other methods have no `<param>`/`<returns>` padding.
- **Sample Command / ValidatedCommand:** Short summary per record; handlers and validator use `/// <inheritdoc/>`.

No runtime changes. All tests pass.